### PR TITLE
fix: update setup-zig action to v2 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
 


### PR DESCRIPTION
## Summary

Updates `mlugg/setup-zig` from v1 to v2 in the release workflow.

## Problem

The v0.1.0 release workflow failed because `mlugg/setup-zig@v1` uses an outdated Zig download format:
- Looks for binaries at `/builds/` instead of `/download/VERSION/`
- Uses old naming convention `zig-platform-arch-version` instead of `zig-arch-platform-version`

This caused 404 errors across all mirrors and the official Zig download server when trying to install Zig 0.15.2.

Failed run: https://github.com/forketyfork/zwanzig/actions/runs/21311457257

## Solution

Updated to `mlugg/setup-zig@v2` which supports the current Zig release URL format and naming convention.