### PR TITLE
fix: enforce release-check validation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,21 @@ permissions:
   contents: write
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Run release checks
+        run: ./scripts/release-check.sh "${{ github.ref_name }}"
+
   release:
+    needs: validate
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/justfile
+++ b/justfile
@@ -24,6 +24,7 @@ lint:
     if [ -f validate.sh ]; then
         shellcheck validate.sh
     fi
+    shellcheck scripts/*.sh
 
     zig fmt --check src/
     zig build run -- src/**/*.zig


### PR DESCRIPTION
## Summary

The release workflow was passing even when `release-check.sh` wasn't run and version wasn't updated in `build.zig.zon`. This happened because the validation script existed but wasn't integrated into the workflow.

## Solution

- Added a `validate` job to `release.yml` that runs `release-check.sh` before any build jobs start
- The `release` job now has `needs: validate`, ensuring builds only proceed if validation passes
- Added `shellcheck scripts/*.sh` to the lint task in `justfile` so all shell scripts in the scripts directory are linted in CI

This ensures version consistency between `build.zig.zon`, README tags, and the git tag is enforced automatically on every release.