### PR TITLE
release v0.7.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zwanzig,
-    .version = "0.6.0",
+    .version = "0.7.0",
     .fingerprint = 0x82777a3c96d925a2,
     .minimum_zig_version = "0.15.2",
     .dependencies = .{},

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -59,7 +59,7 @@ Without arguments, zwanzig scans the current directory for `.zig` files. It skip
 Add zwanzig to your project:
 
 ```bash
-zig fetch --save https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.6.0.tar.gz
+zig fetch --save https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.7.0.tar.gz
 ```
 
 Then wire a lint step in your `build.zig`:


### PR DESCRIPTION
Release v0.7.0

- Bump version metadata to 0.7.0
- Update zig fetch tag reference in docs/USAGE.md

Validation
- just release-check v0.7.0
