### PR TITLE
fix: address four engine correctness bugs

### DIFF
--- a/src/analyzer.zig
+++ b/src/analyzer.zig
@@ -218,9 +218,15 @@ pub const Analyzer = struct {
 
     pub fn mergeResult(self: *Analyzer, result: *AnalysisResult) !void {
         self.analysis_stats.merge(result.stats);
+        // Reserve capacity upfront so append can't fail mid-way.
+        // This prevents use-after-free on error: if ensureUnusedCapacity fails,
+        // we haven't moved any diagnostics yet, so errdefer in analyzeFile
+        // can safely free result's diagnostics.
+        try self.diagnostics.ensureUnusedCapacity(self.allocator, result.diagnostics.items.len);
         for (result.diagnostics.items) |diag| {
-            try self.diagnostics.append(self.allocator, diag);
+            self.diagnostics.appendAssumeCapacity(diag);
         }
+        // Only free the backing array, not the diagnostics (now owned by self)
         result.diagnostics.deinit(self.allocator);
         result.diagnostics = .empty;
     }

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -211,7 +211,8 @@ pub const Cache = struct {
         };
 
         if (!entry.key.eql(key)) {
-            return CacheError.CacheCorrupted;
+            // Key mismatch indicates corruption; treat as cache miss
+            return null;
         }
 
         const data = try self.allocator.alloc(u8, entry.data_len);
@@ -219,8 +220,9 @@ pub const Cache = struct {
 
         const bytes_read = try file.readAll(data);
         if (bytes_read != entry.data_len) {
+            // Incomplete read indicates corruption; treat as cache miss
             self.allocator.free(data);
-            return CacheError.CacheCorrupted;
+            return null;
         }
 
         return data;

--- a/src/engine/analysis/branch_constraints.zig
+++ b/src/engine/analysis/branch_constraints.zig
@@ -33,8 +33,9 @@ pub fn mixin(comptime _Engine: type) type {
                 // First check if the condition is a literal boolean
                 if (_Engine.literals.evaluateLiteral(self, cond_node)) |literal_val| {
                     if (literal_val.toBool()) |bool_val| {
-                        const var_key = ids.varId(cond_node);
-                        return Constraint.boolCheck(var_key, bool_val);
+                        // Use literalBool for compile-time known conditions to enable
+                        // proper branch pruning (e.g., if (false) should be pruned)
+                        return Constraint.literalBool(bool_val);
                     }
                 }
 

--- a/src/engine/constraints.zig
+++ b/src/engine/constraints.zig
@@ -43,6 +43,11 @@ pub const Constraint = union(enum) {
         var_id: VarId,
         expected: bool, // true = var must be true, false = var must be false
     },
+    /// Literal boolean constraint: always satisfiable (true) or never satisfiable (false).
+    /// Used for literal `true`/`false` conditions to enable proper branch pruning.
+    literal_bool: struct {
+        value: bool, // true = always satisfiable, false = never satisfiable
+    },
 
     pub fn eql(self: Constraint, other: Constraint) bool {
         return switch (self) {
@@ -62,6 +67,10 @@ pub const Constraint = union(enum) {
                 .bool_check => |bc2| bc1.var_id == bc2.var_id and bc1.expected == bc2.expected,
                 else => false,
             },
+            .literal_bool => |lb1| switch (other) {
+                .literal_bool => |lb2| lb1.value == lb2.value,
+                else => false,
+            },
         };
     }
 
@@ -72,6 +81,7 @@ pub const Constraint = union(enum) {
             .null_check => 1,
             .var_compare => 2,
             .bool_check => 3,
+            .literal_bool => 4,
         };
         hasher.update(&[_]u8{tag_byte});
         switch (self) {
@@ -98,6 +108,9 @@ pub const Constraint = union(enum) {
                 hasher.update(std.mem.asBytes(&var_id));
                 hasher.update(&[_]u8{if (bc.expected) 1 else 0});
             },
+            .literal_bool => |lb| {
+                hasher.update(&[_]u8{if (lb.value) 1 else 0});
+            },
         }
         return hasher.final();
     }
@@ -122,6 +135,12 @@ pub const Constraint = union(enum) {
         return .{ .bool_check = .{ .var_id = var_id, .expected = expected } };
     }
 
+    /// Create a literal boolean constraint for compile-time known conditions.
+    /// Use this for literal `true`/`false` to enable proper branch pruning.
+    pub fn literalBool(value: bool) Constraint {
+        return .{ .literal_bool = .{ .value = value } };
+    }
+
     /// Get the negation of this constraint (for else branches).
     pub fn negate(self: Constraint) Constraint {
         return switch (self) {
@@ -142,6 +161,9 @@ pub const Constraint = union(enum) {
             .bool_check => |bc| .{ .bool_check = .{
                 .var_id = bc.var_id,
                 .expected = !bc.expected,
+            } },
+            .literal_bool => |lb| .{ .literal_bool = .{
+                .value = !lb.value,
             } },
         };
     }
@@ -296,6 +318,12 @@ pub const ConstraintManager = struct {
                 }
             },
             .var_compare => {},
+            .literal_bool => |lb| {
+                // literal_bool(false) is a contradiction by itself
+                if (!lb.value) {
+                    self.has_contradiction = true;
+                }
+            },
         }
     }
 
@@ -323,6 +351,10 @@ pub const ConstraintManager = struct {
             .var_compare => {
                 // Variable comparisons are conservatively satisfiable unless we have concrete values
                 return true;
+            },
+            .literal_bool => |lb| {
+                // Literal boolean constraints are definitively satisfiable or not
+                return lb.value;
             },
         }
     }
@@ -358,6 +390,15 @@ pub const ConstraintManager = struct {
                 }
             },
             .var_compare => return false,
+            .literal_bool => |lb1| {
+                switch (c2) {
+                    .literal_bool => |lb2| {
+                        // literal_bool(true) AND literal_bool(false) is contradictory
+                        return lb1.value != lb2.value;
+                    },
+                    else => return false,
+                }
+            },
         }
     }
 
@@ -456,6 +497,11 @@ pub const ConstraintManager = struct {
                 return refineValueWithBoolCheck(value, bc.expected);
             },
             .var_compare => return value, // No refinement for var-var comparisons yet
+            .literal_bool => |lb| {
+                // Literal bool constraints don't refine variable values;
+                // they only affect path satisfiability
+                return if (lb.value) value else null;
+            },
         }
     }
 };
@@ -970,4 +1016,97 @@ test "ConstraintManager subsumes ordering" {
 
     try testing.expect(general.subsumes(&specific));
     try testing.expect(!specific.subsumes(&general));
+}
+
+test "literal_bool constraint creation and equality" {
+    const testing = std.testing;
+
+    const c_true = Constraint.literalBool(true);
+    const c_true2 = Constraint.literalBool(true);
+    const c_false = Constraint.literalBool(false);
+
+    try testing.expect(c_true.eql(c_true2));
+    try testing.expect(!c_true.eql(c_false));
+}
+
+test "literal_bool constraint negation" {
+    const testing = std.testing;
+
+    const c_true = Constraint.literalBool(true);
+    const neg = c_true.negate();
+    try testing.expect(neg.eql(Constraint.literalBool(false)));
+
+    const c_false = Constraint.literalBool(false);
+    const neg2 = c_false.negate();
+    try testing.expect(neg2.eql(Constraint.literalBool(true)));
+}
+
+test "literal_bool satisfiability - true is always satisfiable" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var env = Environment.init(allocator);
+    defer env.deinit();
+
+    var cm = ConstraintManager.init(allocator);
+    defer cm.deinit();
+
+    // literal_bool(true) should always be satisfiable
+    try cm.addConstraint(Constraint.literalBool(true));
+    try testing.expect(cm.isSatisfiable(&env));
+}
+
+test "literal_bool satisfiability - false is never satisfiable" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var env = Environment.init(allocator);
+    defer env.deinit();
+
+    var cm = ConstraintManager.init(allocator);
+    defer cm.deinit();
+
+    // literal_bool(false) should never be satisfiable (it's a contradiction)
+    try cm.addConstraint(Constraint.literalBool(false));
+    try testing.expect(!cm.isSatisfiable(&env));
+}
+
+test "literal_bool causes contradiction when false" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var cm = ConstraintManager.init(allocator);
+    defer cm.deinit();
+
+    // Adding literal_bool(false) should mark the constraint manager as contradictory
+    try cm.addConstraint(Constraint.literalBool(false));
+    try testing.expect(cm.has_contradiction);
+
+    // literal_bool(true) should not cause contradiction
+    var cm2 = ConstraintManager.init(allocator);
+    defer cm2.deinit();
+
+    try cm2.addConstraint(Constraint.literalBool(true));
+    try testing.expect(!cm2.has_contradiction);
+}
+
+test "literal_bool refineValue behavior" {
+    const testing = std.testing;
+
+    // literal_bool(true) doesn't change the value
+    const unchanged = ConstraintManager.refineValue(.unknown, Constraint.literalBool(true));
+    try testing.expect(unchanged != null);
+    try testing.expect(unchanged.?.eql(.unknown));
+
+    // literal_bool(false) returns null (unsatisfiable path)
+    const pruned = ConstraintManager.refineValue(.unknown, Constraint.literalBool(false));
+    try testing.expect(pruned == null);
+
+    // Also works with concrete values
+    const concrete_unchanged = ConstraintManager.refineValue(.{ .concrete_int = 42 }, Constraint.literalBool(true));
+    try testing.expect(concrete_unchanged != null);
+    try testing.expect(concrete_unchanged.?.eql(.{ .concrete_int = 42 }));
+
+    const concrete_pruned = ConstraintManager.refineValue(.{ .concrete_int = 42 }, Constraint.literalBool(false));
+    try testing.expect(concrete_pruned == null);
 }

--- a/src/engine/graph.zig
+++ b/src/engine/graph.zig
@@ -45,6 +45,9 @@ pub const ExplodedNode = struct {
     /// Compute a combined hash for point and state (used for deduplication)
     pub fn computeKey(point: ProgramPoint, state: *ProgramState) u64 {
         var hasher = std.hash.Wyhash.init(0);
+        // Include CFG identity to prevent collisions across different CFGs
+        // during interprocedural analysis
+        hasher.update(std.mem.asBytes(&@intFromPtr(point.cfg)));
         const node_index = ids.cfgIndex(point.node_index);
         hasher.update(std.mem.asBytes(&node_index));
         hasher.update(std.mem.asBytes(&point.kind));

--- a/src/engine/state.zig
+++ b/src/engine/state.zig
@@ -383,16 +383,19 @@ pub const ProgramState = struct {
         self.invalidateCache();
 
         // Refine the relevant variable's value based on the constraint
-        const var_id = switch (constraint) {
+        const var_id: ?VarId = switch (constraint) {
             .int_compare => |ic| ic.var_id,
             .null_check => |nc| nc.var_id,
             .bool_check => |bc| bc.var_id,
             .var_compare => |vc| vc.var1_id,
+            .literal_bool => null, // No variable to refine for literal bool constraints
         };
 
-        if (self.env.get(var_id)) |current_val| {
-            if (ConstraintManager.refineValue(current_val, constraint)) |refined| {
-                try self.env.set(var_id, refined);
+        if (var_id) |vid| {
+            if (self.env.get(vid)) |current_val| {
+                if (ConstraintManager.refineValue(current_val, constraint)) |refined| {
+                    try self.env.set(vid, refined);
+                }
             }
         }
     }

--- a/src/engine/summary.zig
+++ b/src/engine/summary.zig
@@ -5,6 +5,7 @@ const Constraint = @import("constraints.zig").Constraint;
 const ConstraintManager = @import("constraints.zig").ConstraintManager;
 const ProgramState = @import("state.zig").ProgramState;
 const AstNodeId = ids.AstNodeId;
+const VarId = ids.VarId;
 
 /// Function summary capturing the effects of a function call.
 /// Summaries store preconditions, postconditions, and error behavior to enable
@@ -87,18 +88,25 @@ pub const FunctionSummary = struct {
     pub fn isApplicable(self: *const FunctionSummary, state: *const ProgramState) bool {
         for (self.preconditions.items) |precond| {
             // Check if the precondition is satisfiable given the current environment
-            const var_id = switch (precond) {
+            const var_id: ?VarId = switch (precond) {
                 .int_compare => |ic| ic.var_id,
                 .null_check => |nc| nc.var_id,
                 .bool_check => |bc| bc.var_id,
                 .var_compare => |vc| vc.var1_id,
+                .literal_bool => |lb| {
+                    // Literal bool preconditions are immediately decidable
+                    if (!lb.value) return false;
+                    continue;
+                },
             };
 
-            if (state.getVar(var_id)) |val| {
-                // Check if the current value is compatible with the precondition
-                const refined = ConstraintManager.refineValue(val, precond);
-                if (refined == null) {
-                    return false; // Precondition not satisfiable
+            if (var_id) |vid| {
+                if (state.getVar(vid)) |val| {
+                    // Check if the current value is compatible with the precondition
+                    const refined = ConstraintManager.refineValue(val, precond);
+                    if (refined == null) {
+                        return false; // Precondition not satisfiable
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR fixes four latent correctness bugs in the analysis engine:

1. **Cache corruption aborts analysis** — Some cache corruption scenarios propagated errors instead of treating them as cache misses, causing the entire analysis to fail
2. **ExplodedGraph deduplication ignores CFG identity** — `computeKey()` didn't include the CFG pointer, potentially causing incorrect node merging across different CFGs during interprocedural analysis
3. **Use-after-free on error path in mergeResult** — If `append` failed mid-way through merging diagnostics, the `errdefer` would free messages that were already shallow-copied to the analyzer
4. **Literal boolean constraints never prune** — `if (false)` branches were still explored because the constraint engine created `boolCheck` constraints on nonexistent var IDs for literals

## Changes

- `src/cache.zig`: Return `null` (cache miss) for all corruption scenarios instead of propagating errors
- `src/engine/graph.zig`: Include CFG pointer in `computeKey()` hash
- `src/analyzer.zig`: Use `ensureUnusedCapacity()` + `appendAssumeCapacity()` to make merge atomic
- `src/engine/constraints.zig`: Add `literal_bool` constraint variant with direct satisfiability
- `src/engine/analysis/branch_constraints.zig`: Use `literalBool()` for literal conditions
- `src/engine/state.zig`, `src/engine/summary.zig`: Handle new constraint variant

## Test plan

- [x] All existing tests pass (`zig build test`)
- [x] Lint passes including zwanzig self-analysis (`just lint`)
- [x] Added 6 unit tests for `literal_bool` constraint behavior
