### PR TITLE
fix(engine): remove dead dropped_state_count counter

### DIFF
--- a/src/analyzer.zig
+++ b/src/analyzer.zig
@@ -156,12 +156,6 @@ pub const Analyzer = struct {
                 self.analysis_stats.total_runs,
             });
         }
-        if (self.analysis_stats.runs_with_drops == 0) return;
-        log.warn("dropped {d} state(s) due to per-point limit across {d} engine run(s) (total runs {d})", .{
-            self.analysis_stats.dropped_states,
-            self.analysis_stats.runs_with_drops,
-            self.analysis_stats.total_runs,
-        });
     }
 
     pub fn isRuleEnabled(self: *const Analyzer, rule_name: []const u8) bool {

--- a/src/checker.zig
+++ b/src/checker.zig
@@ -23,17 +23,11 @@ pub const CachedArtifacts = cached_artifacts_mod.CachedArtifacts;
 
 pub const AnalysisStats = struct {
     total_runs: u64 = 0,
-    runs_with_drops: u64 = 0,
-    dropped_states: u64 = 0,
     widened_nodes: u64 = 0,
     widening_converged: u64 = 0,
 
-    pub fn recordRun(self: *AnalysisStats, dropped_states: u32) void {
+    pub fn recordRun(self: *AnalysisStats) void {
         self.total_runs += 1;
-        if (dropped_states > 0) {
-            self.runs_with_drops += 1;
-            self.dropped_states += dropped_states;
-        }
     }
 
     pub fn recordWidening(self: *AnalysisStats, widened: u32, converged: u32) void {
@@ -43,8 +37,6 @@ pub const AnalysisStats = struct {
 
     pub fn merge(self: *AnalysisStats, other: AnalysisStats) void {
         self.total_runs += other.total_runs;
-        self.runs_with_drops += other.runs_with_drops;
-        self.dropped_states += other.dropped_states;
         self.widened_nodes += other.widened_nodes;
         self.widening_converged += other.widening_converged;
     }

--- a/src/checkers/divide_by_zero_engine.zig
+++ b/src/checkers/divide_by_zero_engine.zig
@@ -77,7 +77,7 @@ pub const DivideByZeroEngineChecker = struct {
             error.AnalysisLimitExceeded => run_ok = false,
         };
         if (context.analysis_stats) |stats| {
-            stats.recordRun(engine.getGraph().getDroppedStateCount());
+            stats.recordRun();
             stats.recordWidening(engine.getGraph().getWidenedNodeCount(), engine.getGraph().getWideningConvergedCount());
         }
 

--- a/src/checkers/empty_catch_engine.zig
+++ b/src/checkers/empty_catch_engine.zig
@@ -184,7 +184,7 @@ pub const EmptyCatchEngineChecker = struct {
             error.AnalysisLimitExceeded => {},
         };
         if (context.analysis_stats) |stats| {
-            stats.recordRun(engine.getGraph().getDroppedStateCount());
+            stats.recordRun();
             stats.recordWidening(engine.getGraph().getWidenedNodeCount(), engine.getGraph().getWideningConvergedCount());
         }
 

--- a/src/checkers/optional_unwrap_engine.zig
+++ b/src/checkers/optional_unwrap_engine.zig
@@ -87,7 +87,7 @@ pub const OptionalUnwrapEngineChecker = struct {
             error.AnalysisLimitExceeded => run_ok = false,
         };
         if (context.analysis_stats) |stats| {
-            stats.recordRun(engine.getGraph().getDroppedStateCount());
+            stats.recordRun();
             stats.recordWidening(engine.getGraph().getWidenedNodeCount(), engine.getGraph().getWideningConvergedCount());
         }
 

--- a/src/checkers/slice_bounds_engine.zig
+++ b/src/checkers/slice_bounds_engine.zig
@@ -77,7 +77,7 @@ pub const SliceBoundsEngineChecker = struct {
             error.AnalysisLimitExceeded => run_ok = false,
         };
         if (context.analysis_stats) |stats| {
-            stats.recordRun(engine.getGraph().getDroppedStateCount());
+            stats.recordRun();
             stats.recordWidening(engine.getGraph().getWidenedNodeCount(), engine.getGraph().getWideningConvergedCount());
         }
 

--- a/src/checkers/store_violations_engine.zig
+++ b/src/checkers/store_violations_engine.zig
@@ -85,7 +85,7 @@ pub const StoreViolationsEngineChecker = struct {
             error.AnalysisLimitExceeded => run_ok = false,
         };
         if (context.analysis_stats) |stats| {
-            stats.recordRun(engine.getGraph().getDroppedStateCount());
+            stats.recordRun();
             stats.recordWidening(engine.getGraph().getWidenedNodeCount(), engine.getGraph().getWideningConvergedCount());
         }
 

--- a/src/checkers/swallowed_error.zig
+++ b/src/checkers/swallowed_error.zig
@@ -84,7 +84,7 @@ pub const SwallowedErrorChecker = struct {
             error.AnalysisLimitExceeded => engine_ok = false,
         };
         if (context.analysis_stats) |stats| {
-            stats.recordRun(engine.getGraph().getDroppedStateCount());
+            stats.recordRun();
             stats.recordWidening(engine.getGraph().getWidenedNodeCount(), engine.getGraph().getWideningConvergedCount());
         }
 

--- a/src/engine/analysis/engine.zig
+++ b/src/engine/analysis/engine.zig
@@ -206,7 +206,7 @@ pub const AnalysisEngine = struct {
         self.max_worklist_steps = steps;
     }
 
-    /// Set the maximum number of states per program point before dropping.
+    /// Set the maximum number of states per program point before cap widening.
     pub fn setMaxStatesPerPoint(self: *AnalysisEngine, max: u32) void {
         self.graph.setMaxStatesPerPoint(max);
     }
@@ -1932,9 +1932,6 @@ test "AnalysisEngine widening simple loop converges without drops" {
     try testing.expect(graph.nodeCount() > 0);
     try testing.expect(graph.nodeCount() <= 20);
 
-    // No states should be dropped
-    try testing.expectEqual(@as(u32, 0), graph.getDroppedStateCount());
-
     // Verify widening infrastructure was used (visit tracking)
     // The header should be tracked for widening even if convergence happened via dedup
     try testing.expect(graph.getTrackedWideningPointCount() >= 1);
@@ -2064,10 +2061,6 @@ test "AnalysisEngine widening branching loop preserves constraints conservativel
 
     // Analysis should complete without issues
     try testing.expect(graph.nodeCount() > 0);
-
-    // Should have explored multiple paths through the loop
-    // With branching, states at the header may be widened
-    try testing.expect(graph.getDroppedStateCount() == 0 or graph.getWidenedNodeCount() > 0);
 }
 
 test "AnalysisEngine widening error path in loop remains sound" {
@@ -2173,9 +2166,6 @@ test "AnalysisEngine widening convergence stops exploration" {
     // (deduplication prevents infinite exploration)
     try testing.expect(graph.nodeCount() > 0);
     try testing.expect(graph.nodeCount() <= 20);
-
-    // No states should be dropped (deduplication is sufficient)
-    try testing.expectEqual(@as(u32, 0), graph.getDroppedStateCount());
 }
 
 test "AnalysisEngine widening regression test with real loop code" {
@@ -2228,10 +2218,7 @@ test "AnalysisEngine widening regression test with real loop code" {
 
         const graph = engine.getGraph();
 
-        // Analysis should complete successfully
+        // Analysis should complete successfully - widening prevents state explosion
         try testing.expect(graph.nodeCount() > 0);
-
-        // Widening should prevent state explosion - no states dropped
-        try testing.expectEqual(@as(u32, 0), graph.getDroppedStateCount());
     }
 }

--- a/src/engine/graph.zig
+++ b/src/engine/graph.zig
@@ -10,7 +10,8 @@ const ProgramState = state_mod.ProgramState;
 const WideningKey = state_mod.WideningKey;
 
 /// Default maximum number of unique states per program point.
-/// Beyond this, new states at the same point are dropped (widening approximation).
+/// Beyond this, new states at the same point are widened into an existing node
+/// with the same calling context (widening approximation).
 const default_max_states_per_point: u32 = 50;
 
 /// A node in the exploded graph, keyed by (ProgramPoint, ProgramState).
@@ -73,10 +74,8 @@ pub const ExplodedGraph = struct {
     point_state_counts: std.AutoHashMap(u64, u32),
     /// Node indices per program point (for subsumption and cap widening)
     point_nodes: std.AutoHashMap(u64, std.ArrayList(u32)),
-    /// Maximum number of unique states per program point before dropping
+    /// Maximum number of unique states per program point before cap widening
     max_states_per_point: u32,
-    /// Count of states dropped due to per-point limit
-    dropped_state_count: u32,
     /// Stored states at widening points (keyed by WideningKey)
     widening_states: std.HashMap(WideningKey, ProgramState, WideningKey.HashContext, std.hash_map.default_max_load_percentage),
     /// Visit count at widening points for delayed widening (keyed by WideningKey)
@@ -95,7 +94,6 @@ pub const ExplodedGraph = struct {
             .point_state_counts = std.AutoHashMap(u64, u32).init(allocator),
             .point_nodes = std.AutoHashMap(u64, std.ArrayList(u32)).init(allocator),
             .max_states_per_point = default_max_states_per_point,
-            .dropped_state_count = 0,
             .widening_states = std.HashMap(WideningKey, ProgramState, WideningKey.HashContext, std.hash_map.default_max_load_percentage).init(allocator),
             .widening_visits = std.HashMap(WideningKey, u32, WideningKey.HashContext, std.hash_map.default_max_load_percentage).init(allocator),
             .widened_nodes = 0,
@@ -134,7 +132,7 @@ pub const ExplodedGraph = struct {
 
     /// Result of getOrCreateNode operation.
     pub const GetOrCreateResult = struct {
-        /// Index of the node (maxInt(u32) if dropped)
+        /// Index of the node
         index: u32,
         /// Whether this is a newly created node
         is_new: bool,
@@ -449,10 +447,6 @@ pub const ExplodedGraph = struct {
         return self.nodes.items.len;
     }
 
-    pub fn getDroppedStateCount(self: *const ExplodedGraph) u32 {
-        return self.dropped_state_count;
-    }
-
     pub fn setMaxStatesPerPoint(self: *ExplodedGraph, max: u32) void {
         self.max_states_per_point = max;
     }
@@ -712,7 +706,6 @@ test "ExplodedGraph widening stats tracking" {
 
     try testing.expectEqual(@as(u32, 0), graph.getWidenedNodeCount());
     try testing.expectEqual(@as(u32, 0), graph.getWideningConvergedCount());
-    try testing.expectEqual(@as(u32, 0), graph.getDroppedStateCount());
 }
 
 test "ExplodedGraph widen-on-cap updates existing node" {
@@ -749,7 +742,6 @@ test "ExplodedGraph widen-on-cap updates existing node" {
     try testing.expect(!result.is_new);
     try testing.expect(result.widening_applied);
     try testing.expect(result.state_updated);
-    try testing.expectEqual(@as(u32, 0), graph.getDroppedStateCount());
 
     const node = graph.getNode(result.index) orelse return error.TestUnexpectedResult;
     const val = node.state.getVar(ids.varId(1)) orelse return error.TestUnexpectedResult;
@@ -788,7 +780,6 @@ test "ExplodedGraph widen-on-cap respects context" {
     try testing.expect(result2.is_new);
     try testing.expect(!result2.widening_applied);
     try testing.expectEqual(@as(usize, 2), graph.nodeCount());
-    try testing.expectEqual(@as(u32, 0), graph.getDroppedStateCount());
 
     if (result2.caller_should_deinit) {
         state2.deinit();


### PR DESCRIPTION
## Summary

Closes #64.

`ExplodedGraph.dropped_state_count` was initialized to zero, exposed via
`getDroppedStateCount()`, and read by tests and `AnalysisStats` aggregation,
but nothing ever incremented it. After the widening rewrite the per-point cap
path widens incoming states into an existing same-context node instead of
dropping them, so the counter sat at zero for every run. The downstream chain
was dead by extension: `AnalysisStats.dropped_states`, `runs_with_drops`, the
`dropped_states` parameter on `recordRun()`, the merge of those fields, and
the `logAnalysisStats` warning "dropped N state(s) due to per-point limit"
that could never fire.

This PR takes option two from the issue's acceptance criteria — remove the
dead field, getter, stats fields, log warning, and test assertions — rather
than retrofitting a drop counter to a path that no longer drops.

## Changes

- `src/engine/graph.zig`: remove the field, the init line, `getDroppedStateCount()`, and the three `expectEqual(0, ...)` assertions; rewrite the "states are dropped" / "maxInt(u32) if dropped" comments to describe the widen-into-existing behavior the code actually performs.
- `src/engine/analysis/engine.zig`: remove the four assertions tied to `getDroppedStateCount()`; fix the `setMaxStatesPerPoint` docstring ("before dropping" → "before cap widening").
- `src/checker.zig`: remove `AnalysisStats.dropped_states` and `runs_with_drops`; drop the `dropped_states` parameter from `recordRun()`; drop both fields from `merge()`.
- `src/analyzer.zig`: remove the dead warning in `logAnalysisStats`.
- `src/checkers/{divide_by_zero,empty_catch,optional_unwrap,slice_bounds,store_violations}_engine.zig` and `src/checkers/swallowed_error.zig`: `stats.recordRun(engine.getGraph().getDroppedStateCount())` → `stats.recordRun()`.

Net diff: 10 files, +13/−49.

## Verification

`just test` and `just lint` both pass. `just lint` runs zwanzig against its
own sources, so the surviving widening stats are exercised end-to-end (the
self-analysis run reports `26392 node(s) widened, 28512 converged across 8319
engine run(s)` and no longer emits a dropped-state warning).
