### PR TITLE
fix(build): work around Zig 0.15.2 macOS 26.x SDK link failure

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,5 +1,13 @@
 # Development notes
 
+## macOS SDK workaround
+
+On macOS 26.x hosts the active `MacOSX.sdk/usr/lib/libSystem.tbd` only advertises `arm64e-macos`, so Zig 0.15.2 cannot link the build runner and emits a long list of undefined libSystem symbols (`__availability_version_check`, `_realpath$DARWIN_EXTSN`, etc.). Upstream tracker: <https://codeberg.org/ziglang/zig/issues/31756>.
+
+`flake.nix`'s Darwin `shellHook` sources `scripts/setup-macos-sdk-workaround.sh`, which detects the broken stub and, when needed, materializes a fake `DEVELOPER_DIR` under `.tmp/macos-sdk-workaround` that points at `MacOSX15.4.sdk` (the most recent SDK that still lists `arm64-macos`). A narrow `xcrun --sdk macosx --show-sdk-path` shim is prepended to `PATH` so Zig's internal SDK lookup picks up the same path. The hook is a no-op when the active SDK already advertises `arm64-macos`, when `MacOSX15.4.sdk` is missing, or on non-Darwin systems.
+
+Remove the script and the corresponding `flake.nix` lines once Zwanzig moves off Zig 0.15.2 or upstream resolves the arm64e-only stub regression.
+
 ## Architecture
 
 Main components:

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,12 @@
             # We need to remove "xcrun" from the PATH. It is injected by
             # some dependency but we need to rely on system Xcode tools
             export PATH=$(echo "$PATH" | ${pkgs.gawk}/bin/awk -v RS=: -v ORS=: '$0 !~ /xcrun/ || $0 == "/usr/bin" {print}' | ${pkgs.gnused}/bin/sed 's/:$//')
+
+            # Zig 0.15.2 cannot link correctly against the arm64e-only macOS 26.x SDK stubs.
+            # Remove this once we move off Zig 0.15.2 or the upstream fix lands.
+            # https://codeberg.org/ziglang/zig/issues/31756
+            project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+            . "$project_root/scripts/setup-macos-sdk-workaround.sh"
           '');
         };
       }

--- a/scripts/setup-macos-sdk-workaround.sh
+++ b/scripts/setup-macos-sdk-workaround.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Work around Zig 0.15.2 failing to link against the macOS 26.x SDK family,
+# whose top-level libSystem.tbd no longer advertises arm64-macos.
+# Upstream tracker: https://codeberg.org/ziglang/zig/issues/31756
+#
+# Remove this once Zwanzig no longer uses Zig 0.15.2, or once Zig's Darwin
+# SDK discovery / linker handles the arm64e-only stub layout correctly.
+
+legacy_sdk="/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk"
+default_stub="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd"
+
+if [ ! -d "$legacy_sdk" ] || [ ! -f "$default_stub" ]; then
+    return 0
+fi
+
+if sed -n '1,5p' "$default_stub" | grep -q 'arm64-macos'; then
+    return 0
+fi
+
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+workaround_root="$project_root/.tmp/macos-sdk-workaround"
+bin_dir="$workaround_root/bin"
+developer_dir="$workaround_root/developer"
+developer_bin_dir="$developer_dir/usr/bin"
+sdk_link="$developer_dir/SDKs/MacOSX.sdk"
+
+mkdir -p "$bin_dir" "$developer_dir/SDKs" "$developer_bin_dir"
+ln -sfn "$legacy_sdk" "$sdk_link"
+
+xcrun_wrapper="$developer_bin_dir/xcrun"
+cat > "$xcrun_wrapper" <<EOF
+#!/bin/sh
+
+if [ "\$1" = "--sdk" ] && [ "\$2" = "macosx" ] && [ "\$3" = "--show-sdk-path" ] && [ "\$#" -eq 3 ]; then
+    printf '%s\n' '$legacy_sdk'
+    exit 0
+fi
+
+exec env DEVELOPER_DIR= /usr/bin/xcrun "\$@"
+EOF
+chmod +x "$xcrun_wrapper"
+ln -sfn "$xcrun_wrapper" "$bin_dir/xcrun"
+
+case ":$PATH:" in
+    *":$bin_dir:"*) ;;
+    *) export PATH="$bin_dir:$PATH" ;;
+esac
+
+export DEVELOPER_DIR="$developer_dir"
+
+echo "Applied Zig 0.15.2 macOS SDK workaround using $legacy_sdk"

--- a/scripts/setup-macos-sdk-workaround.sh
+++ b/scripts/setup-macos-sdk-workaround.sh
@@ -4,32 +4,43 @@
 # whose top-level libSystem.tbd no longer advertises arm64-macos.
 # Upstream tracker: https://codeberg.org/ziglang/zig/issues/31756
 #
+# Designed to be sourced from the Nix dev shell's shellHook so the exports
+# below reach the calling environment. If executed directly the function body
+# still runs but PATH/DEVELOPER_DIR changes will not propagate.
+#
 # Remove this once Zwanzig no longer uses Zig 0.15.2, or once Zig's Darwin
 # SDK discovery / linker handles the arm64e-only stub layout correctly.
 
-legacy_sdk="/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk"
-default_stub="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd"
+_zwanzig_setup_macos_sdk_workaround() {
+    legacy_sdk="/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk"
 
-if [ ! -d "$legacy_sdk" ] || [ ! -f "$default_stub" ]; then
-    return 0
-fi
+    if [ ! -d "$legacy_sdk" ]; then
+        return 0
+    fi
 
-if sed -n '1,5p' "$default_stub" | grep -q 'arm64-macos'; then
-    return 0
-fi
+    active_sdk=$(/usr/bin/xcrun --sdk macosx --show-sdk-path 2>/dev/null) || return 0
+    active_stub="$active_sdk/usr/lib/libSystem.tbd"
 
-project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-workaround_root="$project_root/.tmp/macos-sdk-workaround"
-bin_dir="$workaround_root/bin"
-developer_dir="$workaround_root/developer"
-developer_bin_dir="$developer_dir/usr/bin"
-sdk_link="$developer_dir/SDKs/MacOSX.sdk"
+    if [ ! -f "$active_stub" ]; then
+        return 0
+    fi
 
-mkdir -p "$bin_dir" "$developer_dir/SDKs" "$developer_bin_dir"
-ln -sfn "$legacy_sdk" "$sdk_link"
+    if sed -n '1,5p' "$active_stub" | grep -q 'arm64-macos'; then
+        return 0
+    fi
 
-xcrun_wrapper="$developer_bin_dir/xcrun"
-cat > "$xcrun_wrapper" <<EOF
+    project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+    workaround_root="$project_root/.tmp/macos-sdk-workaround"
+    bin_dir="$workaround_root/bin"
+    developer_dir="$workaround_root/developer"
+    developer_bin_dir="$developer_dir/usr/bin"
+    sdk_link="$developer_dir/SDKs/MacOSX.sdk"
+
+    mkdir -p "$bin_dir" "$developer_dir/SDKs" "$developer_bin_dir"
+    ln -sfn "$legacy_sdk" "$sdk_link"
+
+    xcrun_wrapper="$developer_bin_dir/xcrun"
+    cat > "$xcrun_wrapper" <<EOF
 #!/bin/sh
 
 if [ "\$1" = "--sdk" ] && [ "\$2" = "macosx" ] && [ "\$3" = "--show-sdk-path" ] && [ "\$#" -eq 3 ]; then
@@ -39,14 +50,20 @@ fi
 
 exec env DEVELOPER_DIR= /usr/bin/xcrun "\$@"
 EOF
-chmod +x "$xcrun_wrapper"
-ln -sfn "$xcrun_wrapper" "$bin_dir/xcrun"
+    chmod +x "$xcrun_wrapper"
+    ln -sfn "$xcrun_wrapper" "$bin_dir/xcrun"
 
-case ":$PATH:" in
-    *":$bin_dir:"*) ;;
-    *) export PATH="$bin_dir:$PATH" ;;
-esac
+    case ":$PATH:" in
+        *":$bin_dir:"*) ;;
+        *) PATH="$bin_dir:$PATH" ;;
+    esac
+    export PATH
 
-export DEVELOPER_DIR="$developer_dir"
+    DEVELOPER_DIR="$developer_dir"
+    export DEVELOPER_DIR
 
-echo "Applied Zig 0.15.2 macOS SDK workaround using $legacy_sdk"
+    echo "Applied Zig 0.15.2 macOS SDK workaround using $legacy_sdk"
+}
+
+_zwanzig_setup_macos_sdk_workaround
+unset -f _zwanzig_setup_macos_sdk_workaround


### PR DESCRIPTION
## Summary

Closes #81.

`zig build` (and therefore `just test` / `just lint`) fails inside `nix
develop` on macOS 26.x hosts because the active
`MacOSX.sdk/usr/lib/libSystem.tbd` only advertises `arm64e-macos`. Zig
0.15.2's Darwin linker cannot resolve symbols against the arm64e-only stub,
so the build runner exits with a long list of undefined libSystem references
(`__availability_version_check`, `_realpath$DARWIN_EXTSN`,
`_arc4random_buf`, `_fork`, …). The existing `flake.nix` already unsets
`SDKROOT` and `DEVELOPER_DIR` to defer to the system Xcode install, which
makes the failure reproduce inside `nix develop` exactly as outside it.

Upstream tracker: <https://codeberg.org/ziglang/zig/issues/31756>.

## Solution

Add `scripts/setup-macos-sdk-workaround.sh` and source it from the Darwin
branch of `flake.nix`'s `shellHook`, after the existing `unset SDKROOT` /
xcrun-PATH-strip block so the workaround applies last. The script:

1. Returns early if `MacOSX15.4.sdk` is not installed, or if the active
   `MacOSX.sdk/usr/lib/libSystem.tbd` already advertises `arm64-macos`. This
   keeps the hook a no-op on unaffected hosts.
2. Otherwise, creates `.tmp/macos-sdk-workaround/{bin,developer/{SDKs,usr/bin}}`,
   symlinks `MacOSX15.4.sdk` (which still lists `arm64-macos`) as
   `developer/SDKs/MacOSX.sdk`, writes a narrow
   `xcrun --sdk macosx --show-sdk-path` wrapper that returns the legacy SDK
   path and delegates all other invocations to `/usr/bin/xcrun` with
   `DEVELOPER_DIR=` cleared, prepends `bin/` to `PATH`, and exports
   `DEVELOPER_DIR`.

`.tmp/` is gitignored, so the materialized directory is per-checkout and not
tracked. The workaround pattern is borrowed from the architect project
(commit `452d1fa`), trimmed to the pieces zwanzig actually needs — no
`build.zig` changes are required because zwanzig does not link against Apple
frameworks.

`docs/DEVELOPMENT.md` gains a new "macOS SDK workaround" section explaining
the regression, what the hook does, and when to remove it.

## Test plan

CI does not currently run on macOS 26.x, so the affected-host check is
manual. Reviewers with the relevant hardware can validate the following.

- [ ] On a macOS 26.x host where `MacOSX.sdk/usr/lib/libSystem.tbd` advertises only `arm64e-macos`:
  - [ ] `rm -rf .zig-cache .tmp/macos-sdk-workaround && nix develop --command just test` prints `Applied Zig 0.15.2 macOS SDK workaround using …` and exits 0
  - [ ] `nix develop --command just lint` also exits 0
- [ ] On a host where the active SDK already lists `arm64-macos` (or any non-Darwin host):
  - [ ] `nix develop` does **not** print the "Applied …" message — confirms the guard short-circuits as expected and no fake `DEVELOPER_DIR` is set
