### PR TITLE
Release v0.12.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zwanzig,
-    .version = "0.12.0",
+    .version = "0.12.1",
     .fingerprint = 0x82777a3c96d925a2,
     .minimum_zig_version = "0.15.2",
     .dependencies = .{},

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -59,7 +59,7 @@ Without arguments, zwanzig scans the current directory for `.zig` files. It skip
 Add zwanzig to your project:
 
 ```bash
-zig fetch --save https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.12.0.tar.gz
+zig fetch --save https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.12.1.tar.gz
 ```
 
 Then wire a lint step in your `build.zig`:


### PR DESCRIPTION
## Issue

Prepare the v0.12.1 patch release after the `appendSlice` false-positive fix landed on `main`.

## Solution

This bumps the package version to `0.12.1` and updates the documented `zig fetch` tag so the release checklist validates the same version that will be tagged.

## Verification

- `just release-check v0.12.1`
