### PR TITLE
perf(cli): swap per-task arena for libc allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Per-file scratch now uses libc's allocator instead of an arena over the page allocator. The engine eagerly frees its temporaries, so the arena was retaining roughly an order of magnitude more memory than the analyzer's actual working set. On engine-heavy inputs (notably `0.12.x` after `defer-frees-escapee` landed) this could push peak RSS into multi-GB territory and OOM on CI runners with limited memory.
+- Per-file scratch now uses libc's allocator instead of an arena over the page allocator. The engine eagerly frees its temporaries, so the arena was retaining roughly an order of magnitude more memory than the analyzer's actual working set. On engine-heavy inputs (notably `0.12.x` after `defer-frees-escapee` landed) this could push peak RSS into multi-GB territory and OOM on CI runners with limited memory (#89).
 
 ## [0.12.1] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Per-file scratch now uses libc's allocator instead of an arena over the page allocator. The engine eagerly frees its temporaries, so the arena was retaining roughly an order of magnitude more memory than the analyzer's actual working set. On engine-heavy inputs (notably `0.12.x` after `defer-frees-escapee` landed) this could push peak RSS into multi-GB territory and OOM on CI runners with limited memory.
+
 ## [0.12.1] - 2026-05-26
 
 ### Fixed

--- a/build.zig
+++ b/build.zig
@@ -20,6 +20,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
     exe_module.addOptions("build_options", options);
 
@@ -44,6 +45,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
     test_module.addOptions("build_options", options);
 

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -23,14 +23,13 @@ const WorkerContext = struct {
 };
 
 fn workerTask(file_index: usize, ctx: *WorkerContext) void {
-    // Use a per-task arena allocator backed by the page allocator.
-    // This eliminates lock contention on the shared GPA during parallel analysis,
-    // as each worker thread has its own independent arena.
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-
+    // Use libc's allocator for per-task scratch. The engine eagerly frees its
+    // temporaries (~1M allocations per file on a 3500-line input), so an arena
+    // ends up retaining all of that churn until file-end, which on
+    // engine-heavy files inflates peak RSS by an order of magnitude. libc
+    // malloc has thread-local caches, so per-task usage doesn't contend.
     const file_path = ctx.files[file_index];
-    const result = ctx.analyzer.analyzeFileResultWithScratchAllocator(file_path, arena.allocator());
+    const result = ctx.analyzer.analyzeFileResultWithScratchAllocator(file_path, std.heap.c_allocator);
     if (result) |r| {
         ctx.results[file_index] = r;
         ctx.errors[file_index] = null;


### PR DESCRIPTION
## Problem

After PR #79 landed in 0.12.0 (defer-frees-escapee rule + switch-arm CFG visits), running zwanzig on engine-heavy codebases blows up to multi-GB RSS:

- On Architect's 75-file Zig source tree (4-core Linux container, 8 GB RAM): peak RSS hits 7.79 GB and the Linux OOM-killer SIGKILLs the process before analysis completes.
- macOS GitHub Actions runners survive (memory compression absorbs the pressure) but at noticeably higher wall time than Linux would have shown if it didn't OOM.

The downstream Architect project (which surfaced the regression) cannot currently run zwanzig on Ubuntu CI because of this. See forketyfork/architect#317 for the failing run.

## Investigation

Bisecting between v0.11.0 and v0.12.1 pinpointed `b65cd4c` ("feat(engine): detect defer-frees-escapee, visit switch arms in CFG") as the introducing commit. Two effects compound there: switch arms are now CFG-traversed (widening node count grew 30,954 → 56,903, ~1.8x), and per-state `Store` clones grew with the wider `DeferredEntry`. Both inflate the *number* and *size* of objects the engine allocates and immediately frees.

The dominant cost wasn't the engine work itself though — it was the per-task arena amplifying that churn. heaptrack on a single 3500-line input (with the arena temporarily replaced so allocations were visible) showed:

- 1,362,469 allocation calls
- 99.35% freed by the engine during the run
- True working heap peak: **8 MB**
- Arena-retained peak on the same input: **633 MB**

The arena (`std.heap.ArenaAllocator` over `std.heap.page_allocator`) was originally introduced to avoid lock contention on a shared allocator across worker threads, but it ignores `free()` calls until `arena.deinit()`. Every byte the engine allocates and "frees" during a file's analysis stays resident until the file is done. After #79 raised the engine's allocation count, that retention exceeded the available memory on standard Linux runners.

## Fix

Pass `std.heap.c_allocator` directly to `analyzeFileResultWithScratchAllocator`. libc malloc has thread-local caches (per-thread arenas in glibc, per-thread free lists in jemalloc/mimalloc), so per-worker usage doesn't contend on a global lock — the arena's original motivation is preserved without the retention cost.

## Measurements

Full Architect source tree (75 files, 35,661 lines), 4-core Linux container, ReleaseFast:

| zwanzig version | scratch allocator | wall | peak RSS | outcome |
|---|---|---|---|---|
| v0.11.0 | arena over page_allocator (current) | 1.96s | 2.82 GB | clean |
| v0.11.0 | c_allocator | 1.22s | 159 MB | clean |
| v0.12.1 | arena over page_allocator (current) | OOM | 7.79 GB | SIGKILL |
| v0.12.1 | arena over smp_allocator | OOM | 7.61 GB | SIGKILL |
| **v0.12.1** | **c_allocator (this PR)** | **6.64s** | **873 MB** | **clean** |
| v0.12.1 | smp_allocator (no arena) | 7.07s | 1.67 GB | clean |

Two things worth noting in the numbers:

1. The arena was already a net loss on v0.11.0 across both axes — switching to `c_allocator` made it faster *and* used 17x less memory. So this PR isn't only about unblocking the 0.12.x regression; it's also a strict improvement on the prior baseline.
2. v0.12.1's wall time is still ~5.4x v0.11.0's even with the arena gone. That's the real algorithmic cost of #79's switch-arm CFG fan-out (independent of allocator choice). Worth addressing separately — widening at switch-merge nodes is the most likely lever — but not blocking for this fix.

## Verification

- `zig build test` — passes (no fixture changes; behavior identical, only memory layout differs)
- `zig fmt --check src/ build.zig` — clean
- macOS native (16 threads): 6.66s, 1.02 GB peak, expected 4 issues found on Architect
- Linux 4-core container (the original OOM environment): 7.57s, 1.4 GB peak, clean exit 1 (issues found, no crash)

## Notes for review

- This adds `link_libc = true` to `exe_module` and `test_module` in `build.zig`. The `fixture_test_module` is rooted at `src/lib.zig`, which doesn't pull in `cli/run.zig`, so it stays as-is. zwanzig didn't link libc before, but every platform Zig 0.15 supports ships libc. If you'd prefer to avoid the libc dependency, `smp_allocator` is a viable runner-up — 1.67 GB peak instead of 873 MB on the same workload — and would keep the build purely freestanding.
- The CFG state-explosion side of the regression is unchanged by this PR. Once memory is no longer the bottleneck, follow-up engine work (widening at switch joins, or canonicalizing `scope_node` in store identity) would bring v0.12.x wall time closer to v0.11.0.
- The CHANGELOG entry references the regression by version range rather than a specific issue number. Happy to switch to `(#N)` once this PR is open if you'd like.
