### PR TITLE
chore(release): bump version to v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-05-27
+
 ### Changed
 
 - Per-file scratch now uses libc's allocator instead of an arena over the page allocator. The engine eagerly frees its temporaries, so the arena was retaining roughly an order of magnitude more memory than the analyzer's actual working set. On engine-heavy inputs (notably `0.12.x` after `defer-frees-escapee` landed) this could push peak RSS into multi-GB territory and OOM on CI runners with limited memory (#89).

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zwanzig,
-    .version = "0.12.1",
+    .version = "0.12.2",
     .fingerprint = 0x82777a3c96d925a2,
     .minimum_zig_version = "0.15.2",
     .dependencies = .{},

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -59,7 +59,7 @@ Without arguments, zwanzig scans the current directory for `.zig` files. It skip
 Add zwanzig to your project:
 
 ```bash
-zig fetch --save https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.12.1.tar.gz
+zig fetch --save https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.12.2.tar.gz
 ```
 
 Then wire a lint step in your `build.zig`:


### PR DESCRIPTION
Release PR for v0.12.2.

## Contents

A single user-visible change since v0.12.1:

- **Per-file scratch allocator switched from `ArenaAllocator` over `page_allocator` to `c_allocator`.** Fixes OOM on Linux CI runners with engine-heavy inputs after the 0.12.0 engine changes (#89).

## Validation

`scripts/release-check.sh v0.12.2` passes: build, full test suite, format check, and zwanzig running against its own source all clean. No new tag mismatches in docs.

## Process

After merge: tag `v0.12.2` from the merged commit and publish the release per `CLAUDE.md`.
