### PR TITLE
Add project-wide `unused-decl` pass for cross-file unused declaration analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `unused-decl` can now run a project-wide pass for explicitly selected analyses, reporting public top-level declarations that are not referenced by any other analyzed file (PR #TBD).
+- `unused-decl` can now run a project-wide pass for explicitly selected analyses, reporting public top-level declarations that are not referenced by any other analyzed file (#91).
 
 ## [0.12.2] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Project-wide `unused-decl` ignores package entrypoint and alias-style public API exports to reduce library facade noise (#91).
+- Project-wide `unused-decl` now keeps declarations that are exposed through another used public declaration's type, signature, field, or initializer surface (#91).
 
 ## [0.12.2] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `unused-decl` can now run a project-wide pass for explicitly selected analyses, reporting public top-level declarations that are not referenced by any other analyzed file (#91).
 
+### Changed
+
+- Project-wide `unused-decl` ignores package entrypoint and alias-style public API exports to reduce library facade noise (#91).
+
 ## [0.12.2] - 2026-05-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `unused-decl` now runs a project-wide pass by default when more than one file is analyzed, reporting public top-level declarations that are not referenced by any other analyzed file (#91).
+- `unused-decl` now runs a project-wide pass when explicitly selected for more than one analyzed file, reporting public top-level declarations that are not referenced by any other analyzed file (#91).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `unused-decl` can now run a project-wide pass for explicitly selected analyses, reporting public top-level declarations that are not referenced by any other analyzed file (PR #TBD).
+
 ## [0.12.2] - 2026-05-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `unused-decl` can now run a project-wide pass for explicitly selected analyses, reporting public top-level declarations that are not referenced by any other analyzed file (#91).
+- `unused-decl` now runs a project-wide pass by default when more than one file is analyzed, reporting public top-level declarations that are not referenced by any other analyzed file (#91).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Project-wide `unused-decl` ignores package entrypoint and alias-style public API exports to reduce library facade noise (#91).
 - Project-wide `unused-decl` now keeps declarations that are exposed through another used public declaration's type, signature, field, or initializer surface (#91).
+- Project-wide `unused-decl` now discovers package roots from analyzed or workspace `build.zig` `root_source_file` entries, ignores `build.zig`'s `build` entrypoint, and recognizes typed receiver and result-location method calls across files (#91).
 
 ## [0.12.2] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `unused-decl` now runs a project-wide pass when explicitly selected for more than one analyzed file, reporting public top-level declarations that are not referenced by any other analyzed file (#91).
+- `unused-decl` now runs a project-wide pass by default when more than one file is analyzed, reporting public top-level declarations that are not referenced by any other analyzed file (#91).
 
 ### Changed
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -91,7 +91,7 @@ Detects unused container-level `const`, `var`, and `fn` declarations that aren't
 - Underscore-prefixed names (e.g., `_unused`) are ignored (explicit opt-out)
 - Special names like `main` and `panic` are ignored (entry points)
 
-When `unused-decl` is explicitly selected with `--do unused-decl` or an `enabled_rules` config and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, allowing whole-project unused API checks without making the default lint noisy for libraries.
+When `unused-decl` is enabled and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, while ignoring package API entrypoints and alias-style re-exports to avoid library facade noise.
 
 **Bad:**
 ```zig

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -91,7 +91,7 @@ Detects unused container-level `const`, `var`, and `fn` declarations that aren't
 - Underscore-prefixed names (e.g., `_unused`) are ignored (explicit opt-out)
 - Special names like `main` and `panic` are ignored (entry points)
 
-When `unused-decl` is explicitly selected and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, while ignoring package API entrypoints and alias-style re-exports to avoid library facade noise. Declarations exposed through another used public declaration's type, signature, field, or initializer surface are treated as used.
+When `unused-decl` is enabled and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, while ignoring package API entrypoints and alias-style re-exports to avoid library facade noise. Declarations exposed through another used public declaration's type, signature, field, or initializer surface are treated as used.
 
 **Bad:**
 ```zig

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -85,11 +85,13 @@ pub fn helper() void {
 
 ### unused-decl
 
-Detects unused container-level `const`, `var`, and `fn` declarations that aren't exported. The check is conservative:
-- Exported (`pub`) declarations are ignored (they may be used externally)
+Detects unused container-level `const`, `var`, and `fn` declarations that aren't exported. The per-file check is conservative:
+- Exported (`pub`) declarations are ignored during default per-file analysis (they may be used externally)
 - `export` and `extern` declarations are ignored (they may be used by other compilation units)
 - Underscore-prefixed names (e.g., `_unused`) are ignored (explicit opt-out)
 - Special names like `main` and `panic` are ignored (entry points)
+
+When `unused-decl` is explicitly selected with `--do unused-decl` or an enabled-rules config and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, allowing whole-project unused API checks without making the default lint noisy for libraries.
 
 **Bad:**
 ```zig

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -91,7 +91,7 @@ Detects unused container-level `const`, `var`, and `fn` declarations that aren't
 - Underscore-prefixed names (e.g., `_unused`) are ignored (explicit opt-out)
 - Special names like `main` and `panic` are ignored (entry points)
 
-When `unused-decl` is enabled and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, while ignoring package API entrypoints and alias-style re-exports to avoid library facade noise. Declarations exposed through another used public declaration's type, signature, field, or initializer surface are treated as used.
+When `unused-decl` is explicitly selected and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, while ignoring package API entrypoints and alias-style re-exports to avoid library facade noise. Declarations exposed through another used public declaration's type, signature, field, or initializer surface are treated as used.
 
 **Bad:**
 ```zig

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -91,7 +91,7 @@ Detects unused container-level `const`, `var`, and `fn` declarations that aren't
 - Underscore-prefixed names (e.g., `_unused`) are ignored (explicit opt-out)
 - Special names like `main` and `panic` are ignored (entry points)
 
-When `unused-decl` is enabled and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, while ignoring package API entrypoints and alias-style re-exports to avoid library facade noise. Declarations exposed through another used public declaration's type, signature, field, or initializer surface are treated as used.
+When `unused-decl` is enabled and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, while ignoring `build.zig`'s `build` entrypoint, package API roots discovered from `root_source_file` in analyzed or workspace `build.zig` files, and alias-style re-exports to avoid library facade noise. Declarations exposed through another used public declaration's type, signature, field, initializer surface, typed receiver method call, or result-location method call are treated as used.
 
 **Bad:**
 ```zig

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -91,7 +91,7 @@ Detects unused container-level `const`, `var`, and `fn` declarations that aren't
 - Underscore-prefixed names (e.g., `_unused`) are ignored (explicit opt-out)
 - Special names like `main` and `panic` are ignored (entry points)
 
-When `unused-decl` is explicitly selected with `--do unused-decl` or an enabled-rules config and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, allowing whole-project unused API checks without making the default lint noisy for libraries.
+When `unused-decl` is explicitly selected with `--do unused-decl` or an `enabled_rules` config and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, allowing whole-project unused API checks without making the default lint noisy for libraries.
 
 **Bad:**
 ```zig

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -91,7 +91,7 @@ Detects unused container-level `const`, `var`, and `fn` declarations that aren't
 - Underscore-prefixed names (e.g., `_unused`) are ignored (explicit opt-out)
 - Special names like `main` and `panic` are ignored (entry points)
 
-When `unused-decl` is enabled and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, while ignoring package API entrypoints and alias-style re-exports to avoid library facade noise.
+When `unused-decl` is enabled and more than one file is analyzed, zwanzig also runs a project pass over all analyzed files. That pass reports public top-level declarations that are not referenced by any other analyzed file, while ignoring package API entrypoints and alias-style re-exports to avoid library facade noise. Declarations exposed through another used public declaration's type, signature, field, or initializer surface are treated as used.
 
 **Bad:**
 ```zig

--- a/src/analysis/allocator_utils.zig
+++ b/src/analysis/allocator_utils.zig
@@ -15,7 +15,7 @@ fn isAllocatorType(type_ctx: ?*TypeContext, expr_node: u32) bool {
     return isAllocatorTypeName(type_str);
 }
 
-pub fn isAllocatorTypeName(type_str: []const u8) bool {
+fn isAllocatorTypeName(type_str: []const u8) bool {
     var slice = type_str;
     while (slice.len > 0 and (slice[0] == '*' or slice[0] == '?')) {
         slice = slice[1..];

--- a/src/analyzer.zig
+++ b/src/analyzer.zig
@@ -206,15 +206,7 @@ pub const Analyzer = struct {
     }
 
     pub fn shouldRunProjectUnusedDecls(self: *const Analyzer) bool {
-        switch (self.rule_filter) {
-            .allowlist => |list| {
-                for (list) |allowed| {
-                    if (std.mem.eql(u8, allowed, "unused-decl")) return true;
-                }
-                return false;
-            },
-            else => return false,
-        }
+        return self.isRuleEnabled("unused-decl");
     }
 
     pub fn analyzeProjectUnusedDecls(self: *Analyzer, files: []const []const u8) !void {
@@ -589,6 +581,22 @@ test "Analyzer.isRuleEnabled: blocklist" {
     try std.testing.expect(!analyzer.isRuleEnabled("empty-catch"));
     try std.testing.expect(!analyzer.isRuleEnabled("unused-var"));
     try std.testing.expect(analyzer.isRuleEnabled("other-rule"));
+}
+
+test "Analyzer.shouldRunProjectUnusedDecls follows rule filter" {
+    const allocator = std.testing.allocator;
+    var analyzer = Analyzer.init(allocator);
+    defer analyzer.deinit();
+
+    try std.testing.expect(analyzer.shouldRunProjectUnusedDecls());
+
+    const allowlist = [_][]const u8{"todo"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+    try std.testing.expect(!analyzer.shouldRunProjectUnusedDecls());
+
+    const blocklist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .blocklist = &blocklist });
+    try std.testing.expect(!analyzer.shouldRunProjectUnusedDecls());
 }
 
 test "Analyzer text output format" {

--- a/src/analyzer.zig
+++ b/src/analyzer.zig
@@ -208,10 +208,7 @@ pub const Analyzer = struct {
     }
 
     pub fn shouldRunProjectUnusedDecls(self: *const Analyzer) bool {
-        return switch (self.rule_filter) {
-            .allowlist => |rules| containsRuleName(rules, "unused-decl"),
-            .none, .blocklist => false,
-        };
+        return self.isRuleEnabled("unused-decl");
     }
 
     pub fn analyzeProjectUnusedDecls(self: *Analyzer, files: []const []const u8) !void {
@@ -593,7 +590,7 @@ test "Analyzer.shouldRunProjectUnusedDecls follows rule filter" {
     var analyzer = Analyzer.init(allocator);
     defer analyzer.deinit();
 
-    try std.testing.expect(!analyzer.shouldRunProjectUnusedDecls());
+    try std.testing.expect(analyzer.shouldRunProjectUnusedDecls());
 
     const allowlist = [_][]const u8{"todo"};
     analyzer.setRuleFilter(.{ .allowlist = &allowlist });

--- a/src/analyzer.zig
+++ b/src/analyzer.zig
@@ -21,6 +21,7 @@ const SarifFormatter = @import("formatters/sarif.zig").SarifFormatter;
 const log = std.log.scoped(.analyzer);
 const diagnostic_mod = @import("diagnostic.zig");
 const suppression = @import("suppression.zig");
+const project_unused_decl = @import("project_unused_decl.zig");
 
 pub const Analyzer = struct {
     allocator: std.mem.Allocator,
@@ -202,6 +203,24 @@ pub const Analyzer = struct {
                 }
             }
         }
+    }
+
+    pub fn shouldRunProjectUnusedDecls(self: *const Analyzer) bool {
+        switch (self.rule_filter) {
+            .allowlist => |list| {
+                for (list) |allowed| {
+                    if (std.mem.eql(u8, allowed, "unused-decl")) return true;
+                }
+                return false;
+            },
+            else => return false,
+        }
+    }
+
+    pub fn analyzeProjectUnusedDecls(self: *Analyzer, files: []const []const u8) !void {
+        if (!self.shouldRunProjectUnusedDecls()) return;
+        try project_unused_decl.analyze(self.allocator, files, &self.diagnostics);
+        std.mem.sort(Diagnostic, self.diagnostics.items, {}, Diagnostic.lessThan);
     }
 
     pub fn analyzeFile(self: *Analyzer, file_path: []const u8) !void {

--- a/src/analyzer.zig
+++ b/src/analyzer.zig
@@ -163,12 +163,7 @@ pub const Analyzer = struct {
         switch (self.rule_filter) {
             .none => return true,
             .allowlist => |list| {
-                for (list) |allowed| {
-                    if (std.mem.eql(u8, rule_name, allowed)) {
-                        return true;
-                    }
-                }
-                return false;
+                return containsRuleName(list, rule_name);
             },
             .blocklist => |list| {
                 for (list) |blocked| {
@@ -179,6 +174,13 @@ pub const Analyzer = struct {
                 return true;
             },
         }
+    }
+
+    fn containsRuleName(list: []const []const u8, rule_name: []const u8) bool {
+        for (list) |item| {
+            if (std.mem.eql(u8, rule_name, item)) return true;
+        }
+        return false;
     }
 
     fn ruleNameLess(a: []const u8, b: []const u8) bool {
@@ -206,7 +208,10 @@ pub const Analyzer = struct {
     }
 
     pub fn shouldRunProjectUnusedDecls(self: *const Analyzer) bool {
-        return self.isRuleEnabled("unused-decl");
+        return switch (self.rule_filter) {
+            .allowlist => |rules| containsRuleName(rules, "unused-decl"),
+            .none, .blocklist => false,
+        };
     }
 
     pub fn analyzeProjectUnusedDecls(self: *Analyzer, files: []const []const u8) !void {
@@ -588,11 +593,15 @@ test "Analyzer.shouldRunProjectUnusedDecls follows rule filter" {
     var analyzer = Analyzer.init(allocator);
     defer analyzer.deinit();
 
-    try std.testing.expect(analyzer.shouldRunProjectUnusedDecls());
+    try std.testing.expect(!analyzer.shouldRunProjectUnusedDecls());
 
     const allowlist = [_][]const u8{"todo"};
     analyzer.setRuleFilter(.{ .allowlist = &allowlist });
     try std.testing.expect(!analyzer.shouldRunProjectUnusedDecls());
+
+    const project_allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &project_allowlist });
+    try std.testing.expect(analyzer.shouldRunProjectUnusedDecls());
 
     const blocklist = [_][]const u8{"unused-decl"};
     analyzer.setRuleFilter(.{ .blocklist = &blocklist });

--- a/src/assertions.zig
+++ b/src/assertions.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const ast_walk = @import("ast_walk.zig");
 
-pub const AssertionKind = enum {
+const AssertionKind = enum {
     boolean,
     equality,
 };
@@ -93,7 +93,7 @@ pub fn buildAssertionScope(
     return scope;
 }
 
-pub fn isTestAssertionName(name: []const u8) bool {
+fn isTestAssertionName(name: []const u8) bool {
     return std.mem.eql(u8, name, "expect") or
         std.mem.eql(u8, name, "expectEqual") or
         std.mem.eql(u8, name, "expectEqualStrings") or

--- a/src/ast_walk.zig
+++ b/src/ast_walk.zig
@@ -613,21 +613,6 @@ fn fillParentMapInternal(tree: *const Ast, node: u32, parent: u32, parent_map: [
     }
 }
 
-pub fn collectNodesByTag(
-    allocator: std.mem.Allocator,
-    tree: *const Ast,
-    root: u32,
-    tag: Ast.Node.Tag,
-    out: *std.ArrayList(u32),
-) !void {
-    var collector = TagCollector{
-        .allocator = allocator,
-        .tag = tag,
-        .out = out,
-    };
-    try walk(TagCollector, tree, root, &collector);
-}
-
 pub fn containsIdentifier(tree: *const Ast, root: u32, target_name: []const u8) bool {
     var finder = IdentifierFinder{
         .target_name = target_name,
@@ -635,28 +620,6 @@ pub fn containsIdentifier(tree: *const Ast, root: u32, target_name: []const u8) 
     walk(IdentifierFinder, tree, root, &finder) catch return false;
     return finder.found;
 }
-
-pub fn containsNode(tree: *const Ast, root: u32, target: u32) bool {
-    if (root == target) return true;
-    var finder = NodeFinder{
-        .target = target,
-    };
-    walk(NodeFinder, tree, root, &finder) catch return false;
-    return finder.found;
-}
-
-const TagCollector = struct {
-    allocator: std.mem.Allocator,
-    tag: Ast.Node.Tag,
-    out: *std.ArrayList(u32),
-    stop: bool = false,
-
-    pub fn visit(self: *TagCollector, _: *const Ast, node: u32, tag: Ast.Node.Tag) !void {
-        if (tag == self.tag) {
-            try self.out.append(self.allocator, node);
-        }
-    }
-};
 
 const IdentifierFinder = struct {
     target_name: []const u8,
@@ -672,19 +635,6 @@ const IdentifierFinder = struct {
         const token = tree.nodes.items(.main_token)[node];
         const name = tree.tokenSlice(token);
         if (std.mem.eql(u8, name, self.target_name)) {
-            self.found = true;
-            self.stop = true;
-        }
-    }
-};
-
-const NodeFinder = struct {
-    target: u32,
-    found: bool = false,
-    stop: bool = false,
-
-    pub fn visit(self: *NodeFinder, _: *const Ast, node: u32, _: Ast.Node.Tag) !void {
-        if (node == self.target) {
             self.found = true;
             self.stop = true;
         }

--- a/src/build_metadata.zig
+++ b/src/build_metadata.zig
@@ -38,7 +38,7 @@ pub const TargetOS = enum {
     }
 };
 
-pub const OptimizeMode = enum {
+const OptimizeMode = enum {
     debug,
     release_safe,
     release_fast,

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const log = std.log.scoped(.cache);
 const BuildMetadata = @import("build_metadata.zig").BuildMetadata;
 
-pub const CacheError = error{
+const CacheError = error{
     CacheCorrupted,
     VersionMismatch,
     OutOfMemory,
@@ -83,7 +83,7 @@ pub const CacheKey = struct {
     }
 };
 
-pub const CacheEntry = struct {
+const CacheEntry = struct {
     version: u32,
     key: CacheKey,
     timestamp: i64,

--- a/src/cached_artifacts.zig
+++ b/src/cached_artifacts.zig
@@ -17,7 +17,7 @@ const magic: [4]u8 = .{ 'Z', 'W', 'C', 'A' };
 
 /// Current format version for cached artifacts.
 /// Increment when the serialization format changes.
-pub const format_version: u32 = 1;
+const format_version: u32 = 1;
 
 /// Cached intermediate artifacts for a source file.
 /// Contains CFGs for all functions and any other precomputed analysis data.

--- a/src/cfg/dot.zig
+++ b/src/cfg/dot.zig
@@ -9,7 +9,7 @@ const log = std.log.scoped(.cfg_dot);
 /// Generate DOT format representation of a CFG for visualization.
 /// The output can be rendered with Graphviz: `dot -Tpng file.dot -o file.png`
 /// or viewed at online tools like edotor.net or viz-js.com
-pub fn generate(cfg: *const Cfg, allocator: std.mem.Allocator) ![]const u8 {
+fn generate(cfg: *const Cfg, allocator: std.mem.Allocator) ![]const u8 {
     var buffer: std.ArrayList(u8) = .empty;
     errdefer buffer.deinit(allocator);
 

--- a/src/cfg/dot.zig
+++ b/src/cfg/dot.zig
@@ -105,16 +105,6 @@ pub fn writeToFile(
     log.debug("dumped CFG to {s}", .{file_path});
 }
 
-/// Print DOT format to stderr for quick debugging.
-pub fn dumpToStderr(cfg: *const Cfg, allocator: std.mem.Allocator) void {
-    const dot = generate(cfg, allocator) catch |err| {
-        std.debug.print("Failed to generate DOT: {}\n", .{err});
-        return;
-    };
-    defer allocator.free(dot);
-    std.debug.print("{s}", .{dot});
-}
-
 // ============================================================================
 // Tests
 // ============================================================================

--- a/src/checkers/divide_by_zero/evaluator.zig
+++ b/src/checkers/divide_by_zero/evaluator.zig
@@ -7,7 +7,7 @@ const AnalysisEngine = engine_mod.AnalysisEngine;
 const ProgramState = @import("../../engine/state.zig").ProgramState;
 const AbstractValue = @import("../../engine/value.zig").AbstractValue;
 
-pub const DenominatorRisk = enum {
+const DenominatorRisk = enum {
     definitely_zero,
     definitely_non_zero,
     maybe_zero,

--- a/src/checkers/slice_bounds/evaluator.zig
+++ b/src/checkers/slice_bounds/evaluator.zig
@@ -5,7 +5,7 @@ const ids = @import("../../ids.zig");
 const Cfg = @import("../../cfg.zig").Cfg;
 const AnalysisEngine = @import("../../engine.zig").AnalysisEngine;
 
-pub const BoundsRisk = enum {
+const BoundsRisk = enum {
     safe,
     definitely_oob,
     possibly_oob,

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -320,6 +320,7 @@ pub fn run() !void {
 
     log.info("analyzing with {d} rule(s) using {d} thread(s)", .{ analyzer.totalCheckerCount(), cli_args.thread_count });
     try analyzeFilesParallel(&analyzer, files, cli_args.thread_count, allocator);
+    try analyzer.analyzeProjectUnusedDecls(files);
     log.info("analysis complete", .{});
     analyzer.logAnalysisStats();
 

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -291,14 +291,7 @@ pub fn run() !void {
     defer std.process.argsFree(allocator, args);
 
     const cli_args = parseCliArgs(allocator, args);
-    defer {
-        allocator.free(cli_args.paths);
-        switch (cli_args.rule_filter) {
-            .allowlist => |list| allocator.free(list),
-            .blocklist => |list| allocator.free(list),
-            .none => {},
-        }
-    }
+    defer args_mod.freeCliArgs(allocator, cli_args);
 
     const final_config = loadMergedConfig(allocator, cli_args);
     defer merge_mod.freeMergedConfig(allocator, cli_args, final_config);

--- a/src/engine/dot.zig
+++ b/src/engine/dot.zig
@@ -17,7 +17,7 @@ const log = std.log.scoped(.engine_dot);
 
 /// Generate DOT format for the full exploded graph.
 /// Shows all (CFG node, state) pairs with edges between them.
-pub fn generateExplodedGraph(
+fn generateExplodedGraph(
     graph: *const ExplodedGraph,
     allocator: std.mem.Allocator,
 ) ![]const u8 {
@@ -101,7 +101,7 @@ pub fn writeExplodedGraphToFile(
 
 /// Generate DOT format for CFG with state annotations.
 /// Shows the original CFG structure with state summary at each node.
-pub fn generateAnnotatedCfg(
+fn generateAnnotatedCfg(
     graph: *const ExplodedGraph,
     allocator: std.mem.Allocator,
 ) ![]const u8 {
@@ -217,7 +217,7 @@ pub fn writeAnnotatedCfgToFile(
 
 /// Generate DOT format for path traces leading to violations.
 /// Shows linear paths from entry to each violation with state info.
-pub fn generatePathTraces(
+fn generatePathTraces(
     graph: *const ExplodedGraph,
     allocator: std.mem.Allocator,
 ) ![]const u8 {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -3,12 +3,16 @@ pub const diagnostic = @import("diagnostic.zig");
 pub const rule = @import("rule.zig");
 pub const checker = @import("checker.zig");
 pub const config = @import("config.zig");
+pub const analyzer = @import("analyzer.zig");
+pub const rule_filter = @import("rule_filter.zig");
 
 pub const Source = source.Source;
 pub const Diagnostic = diagnostic.Diagnostic;
 pub const Severity = diagnostic.Severity;
 pub const Rule = rule.Rule;
 pub const Checker = checker.Checker;
+pub const Analyzer = analyzer.Analyzer;
+pub const RuleFilter = rule_filter.RuleFilter;
 
 pub const rules = struct {
     pub const dupe_import = @import("rules/dupe_import.zig");

--- a/src/project_unused_decl.zig
+++ b/src/project_unused_decl.zig
@@ -101,6 +101,7 @@ pub fn analyze(
     }
 
     for (files.items, 0..) |*file, file_index| {
+        if (isPublicApiFile(files.items, file.path)) continue;
         try collectPublicRootDecls(allocator, &file.tree, file_index, &decls);
     }
 
@@ -188,6 +189,7 @@ fn extractPublicVarDecl(
     const full = tree.fullVarDecl(@enumFromInt(node_idx)) orelse return null;
     if (!isPubToken(tree, full.visib_token)) return null;
     if (full.extern_export_token != null) return null;
+    if (isPublicAliasDecl(tree, full)) return null;
 
     const token_tags = tree.tokens.items(.tag);
     const name_token = full.ast.mut_token + 1;
@@ -302,6 +304,125 @@ fn isPubToken(tree: *const std.zig.Ast, token: ?std.zig.Ast.TokenIndex) bool {
     return tree.tokenTag(tok) == .keyword_pub;
 }
 
+fn isPublicEntrypointPath(path: []const u8) bool {
+    return std.mem.eql(u8, path, "src/lib.zig") or std.mem.endsWith(u8, path, "/src/lib.zig");
+}
+
+fn isPublicApiFile(files: []const FileInfo, path: []const u8) bool {
+    if (isPublicEntrypointPath(path)) return true;
+
+    for (files) |*file| {
+        if (!isPublicEntrypointPath(file.path)) continue;
+        if (filePubliclyImportsPath(file, path)) return true;
+    }
+    return false;
+}
+
+fn filePubliclyImportsPath(file: *const FileInfo, target_path: []const u8) bool {
+    const tags = file.tree.nodes.items(.tag);
+
+    for (file.tree.rootDecls()) |decl_idx| {
+        const idx = @intFromEnum(decl_idx);
+        if (idx >= tags.len) continue;
+        if (!isVarDeclTag(tags[idx])) continue;
+        if (publicVarDeclImportsPath(&file.tree, @intCast(idx), file.path, target_path)) return true;
+    }
+    return false;
+}
+
+fn publicVarDeclImportsPath(
+    tree: *const std.zig.Ast,
+    node_idx: u32,
+    importer_path: []const u8,
+    target_path: []const u8,
+) bool {
+    const full = tree.fullVarDecl(@enumFromInt(node_idx)) orelse return false;
+    if (!isPubToken(tree, full.visib_token)) return false;
+
+    const init_node = full.ast.init_node.unwrap() orelse return false;
+    const init_idx = @intFromEnum(init_node);
+    const tags = tree.nodes.items(.tag);
+    if (init_idx >= tags.len) return false;
+
+    switch (tags[init_idx]) {
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => {
+            const import_path = importPathFromBuiltinCall(tree, init_idx) orelse return false;
+            return importResolvesToPath(importer_path, import_path, target_path);
+        },
+        else => return false,
+    }
+}
+
+fn isVarDeclTag(tag: std.zig.Ast.Node.Tag) bool {
+    return switch (tag) {
+        .simple_var_decl,
+        .aligned_var_decl,
+        .global_var_decl,
+        .local_var_decl,
+        => true,
+        else => false,
+    };
+}
+
+fn isPublicAliasDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) bool {
+    if (tree.tokenTag(full.ast.mut_token) != .keyword_const) return false;
+
+    const init_node = full.ast.init_node.unwrap() orelse return false;
+    const init_idx = @intFromEnum(init_node);
+    const tags = tree.nodes.items(.tag);
+    if (init_idx >= tags.len) return false;
+
+    return switch (tags[init_idx]) {
+        .identifier,
+        .field_access,
+        => true,
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => isImportBuiltinCall(tree, init_idx),
+        else => false,
+    };
+}
+
+fn isImportBuiltinCall(tree: *const std.zig.Ast, node_idx: usize) bool {
+    return importPathFromBuiltinCall(tree, node_idx) != null;
+}
+
+fn importPathFromBuiltinCall(tree: *const std.zig.Ast, node_idx: usize) ?[]const u8 {
+    const main_tokens = tree.nodes.items(.main_token);
+    if (node_idx >= main_tokens.len) return null;
+    const token = main_tokens[node_idx];
+    if (token >= tree.tokens.len) return null;
+    if (!std.mem.eql(u8, tree.tokenSlice(token), "@import")) return null;
+
+    const token_tags = tree.tokens.items(.tag);
+    var scan_token = token + 1;
+    const end_token = @min(token_tags.len, token + 6);
+    while (scan_token < end_token) : (scan_token += 1) {
+        if (token_tags[scan_token] != .string_literal) continue;
+        const literal = tree.tokenSlice(scan_token);
+        if (literal.len < 2) return null;
+        return literal[1 .. literal.len - 1];
+    }
+    return null;
+}
+
+fn importResolvesToPath(importer_path: []const u8, import_path: []const u8, target_path: []const u8) bool {
+    if (std.mem.eql(u8, import_path, target_path)) return true;
+
+    const importer_dir = std.fs.path.dirname(importer_path) orelse "";
+    if (importer_dir.len == 0) return std.mem.eql(u8, import_path, target_path);
+
+    var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const resolved = std.fmt.bufPrint(&resolved_buf, "{s}/{s}", .{ importer_dir, import_path }) catch return false;
+    return std.mem.eql(u8, resolved, target_path);
+}
+
 fn classifyVarDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) DeclKind {
     if (full.ast.init_node.unwrap()) |init_node| {
         if (isContainerTag(tree.nodes.items(.tag)[@intFromEnum(init_node)])) return .type_decl;
@@ -367,4 +488,11 @@ fn isContainerTag(tag: std.zig.Ast.Node.Tag) bool {
         => true,
         else => false,
     };
+}
+
+test "project unused declarations recognize public entrypoint path" {
+    try std.testing.expect(isPublicEntrypointPath("src/lib.zig"));
+    try std.testing.expect(isPublicEntrypointPath("workspace/src/lib.zig"));
+    try std.testing.expect(!isPublicEntrypointPath("src/main.zig"));
+    try std.testing.expect(!isPublicEntrypointPath("test/fixtures/project_unused_decl/lib.zig"));
 }

--- a/src/project_unused_decl.zig
+++ b/src/project_unused_decl.zig
@@ -366,7 +366,7 @@ fn publicVarDeclImportsPath(
         .builtin_call_two_comma,
         => {
             const import_path = importPathFromBuiltinCall(tree, init_idx) orelse return false;
-            return importResolvesToPath(importer_path, import_path, target_path);
+            return importMayResolveToPath(importer_path, import_path, target_path);
         },
         else => return false,
     }
@@ -396,8 +396,8 @@ fn isPublicAliasDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) b
     const public_name = tree.tokenSlice(name_token);
 
     return switch (tags[init_idx]) {
-        .identifier => isTypeLikeAlias(public_name, identifierName(tree, init_idx) orelse return false),
-        .field_access => isTypeLikeAlias(public_name, fieldAccessName(tree, init_idx) orelse return false),
+        .identifier => isReexportAlias(public_name, identifierName(tree, init_idx) orelse return false),
+        .field_access => isReexportAlias(public_name, fieldAccessName(tree, init_idx) orelse return false),
         .builtin_call,
         .builtin_call_comma,
         .builtin_call_two,
@@ -461,7 +461,9 @@ fn collectProjectUsedDecls(
     @memset(used, false);
 
     for (decls, 0..) |decl, decl_index| {
-        if (isReferencedFromAnotherFile(files, decl)) used[decl_index] = true;
+        if (isReferencedWithinDeclFile(files[decl.file_index], decl) or isReferencedFromAnotherFile(files, decl)) {
+            used[decl_index] = true;
+        }
     }
 
     var changed = true;
@@ -476,12 +478,28 @@ fn collectProjectUsedDecls(
     return used;
 }
 
+fn isReferencedWithinDeclFile(file: FileInfo, decl: DeclInfo) bool {
+    const tags = file.tree.nodes.items(.tag);
+    const main_tokens = file.tree.nodes.items(.main_token);
+
+    for (tags, 0..) |tag, node_index| {
+        if (node_index == decl.node_index) continue;
+        if (tag != .identifier) continue;
+        if (node_index >= main_tokens.len) continue;
+
+        const name = normalizeIdentifier(file.tree.tokenSlice(main_tokens[node_index]));
+        if (std.mem.eql(u8, name, decl.normalized_name)) return true;
+    }
+
+    return false;
+}
+
 fn isReferencedFromAnotherFile(files: []const FileInfo, decl: DeclInfo) bool {
     const decl_file = files[decl.file_index];
     for (files, 0..) |*file, file_index| {
         if (file_index == decl.file_index) continue;
         if (std.mem.eql(u8, file.path, decl_file.path)) continue;
-        if (fileReferencesDecl(file, decl_file.path, decl.normalized_name)) return true;
+        if (fileReferencesDecl(files, file, decl_file.path, decl.normalized_name)) return true;
     }
     return false;
 }
@@ -689,13 +707,14 @@ const PublicSurfaceScanner = struct {
     }
 };
 
-fn fileReferencesDecl(file: *const FileInfo, decl_path: []const u8, normalized_name: []const u8) bool {
-    if (fileReferencesDeclByFieldAccess(&file.tree, file.path, decl_path, normalized_name)) return true;
+fn fileReferencesDecl(files: []const FileInfo, file: *const FileInfo, decl_path: []const u8, normalized_name: []const u8) bool {
+    if (fileReferencesDeclByFieldAccess(files, &file.tree, file.path, decl_path, normalized_name)) return true;
     if (fileUsingnamespaceImportsPath(&file.tree, file.path, decl_path) and fileReferencesBareName(&file.tree, normalized_name)) return true;
     return false;
 }
 
 fn fileReferencesDeclByFieldAccess(
+    files: []const FileInfo,
     tree: *const std.zig.Ast,
     importer_path: []const u8,
     decl_path: []const u8,
@@ -711,7 +730,7 @@ fn fileReferencesDeclByFieldAccess(
         if (!std.mem.eql(u8, slice, normalized_name)) continue;
 
         const lhs = @intFromEnum(datas[node_index].node_and_token[0]);
-        if (nodeImportsPath(tree, lhs, importer_path, decl_path)) return true;
+        if (nodeImportsPath(files, tree, lhs, importer_path, decl_path)) return true;
     }
     return false;
 }
@@ -730,6 +749,7 @@ fn fileReferencesBareName(tree: *const std.zig.Ast, normalized_name: []const u8)
 }
 
 fn nodeImportsPath(
+    files: []const FileInfo,
     tree: *const std.zig.Ast,
     node: usize,
     importer_path: []const u8,
@@ -749,7 +769,18 @@ fn nodeImportsPath(
         .builtin_call_two_comma,
         => {
             const import_path = importPathFromBuiltinCall(tree, node) orelse return false;
-            return importResolvesToPath(importer_path, import_path, target_path);
+            return importMayResolveToPath(importer_path, import_path, target_path);
+        },
+        .field_access => {
+            const datas = tree.nodes.items(.data);
+            const lhs = @intFromEnum(datas[node].node_and_token[0]);
+            const field_name = normalizeIdentifier(tree.tokenSlice(datas[node].node_and_token[1]));
+
+            for (files) |*candidate| {
+                if (!nodeImportsPath(files, tree, lhs, importer_path, candidate.path)) continue;
+                if (filePublicMemberImportsPath(candidate, field_name, target_path)) return true;
+            }
+            return false;
         },
         else => return false,
     }
@@ -774,8 +805,7 @@ fn importAliasResolvesToPath(
         if (!std.mem.eql(u8, name, alias_name)) continue;
 
         const init_node = full.ast.init_node.unwrap() orelse continue;
-        const import_path = importPathFromBuiltinCall(tree, @intFromEnum(init_node)) orelse continue;
-        if (importResolvesToPath(importer_path, import_path, target_path)) return true;
+        if (initNodeImportsPath(tree, @intFromEnum(init_node), importer_path, target_path)) return true;
     }
 
     return false;
@@ -795,7 +825,7 @@ fn fileUsingnamespaceImportsPath(
         if (!std.mem.eql(u8, tree.tokenSlice(@intCast(import_token)), "@import")) continue;
 
         const import_path = importPathFromBuiltinToken(tree, import_token) orelse continue;
-        if (importResolvesToPath(importer_path, import_path, target_path)) return true;
+        if (importMayResolveToPath(importer_path, import_path, target_path)) return true;
     }
 
     return false;
@@ -818,7 +848,7 @@ fn publicUsingnamespaceImportsPath(
         if (!std.mem.eql(u8, tree.tokenSlice(@intCast(import_token)), "@import")) continue;
 
         const import_path = importPathFromBuiltinToken(tree, import_token) orelse continue;
-        if (importResolvesToPath(importer_path, import_path, target_path)) return true;
+        if (importMayResolveToPath(importer_path, import_path, target_path)) return true;
     }
 
     return false;
@@ -836,6 +866,64 @@ fn importPathFromBuiltinToken(tree: *const std.zig.Ast, token: usize) ?[]const u
     if (literal.len < 2) return null;
     return literal[1 .. literal.len - 1];
 }
+
+fn initNodeImportsPath(
+    tree: *const std.zig.Ast,
+    node: usize,
+    importer_path: []const u8,
+    target_path: []const u8,
+) bool {
+    const tags = tree.nodes.items(.tag);
+    if (node >= tags.len) return false;
+
+    switch (tags[node]) {
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => {
+            const import_path = importPathFromBuiltinCall(tree, node) orelse return false;
+            return importMayResolveToPath(importer_path, import_path, target_path);
+        },
+        else => {
+            var scanner = ImportPathScanner{
+                .importer_path = importer_path,
+                .target_path = target_path,
+            };
+            ast_walk.walk(ImportPathScanner, tree, @intCast(node), &scanner) catch return false;
+            return scanner.found;
+        },
+    }
+}
+
+const ImportPathScanner = struct {
+    importer_path: []const u8,
+    target_path: []const u8,
+    found: bool = false,
+    stop: bool = false,
+
+    pub fn visit(
+        self: *ImportPathScanner,
+        tree: *const std.zig.Ast,
+        node: u32,
+        tag: std.zig.Ast.Node.Tag,
+    ) anyerror!void {
+        switch (tag) {
+            .builtin_call,
+            .builtin_call_comma,
+            .builtin_call_two,
+            .builtin_call_two_comma,
+            => {
+                const import_path = importPathFromBuiltinCall(tree, node) orelse return;
+                if (importMayResolveToPath(self.importer_path, import_path, self.target_path)) {
+                    self.found = true;
+                    self.stop = true;
+                }
+            },
+            else => {},
+        }
+    }
+};
 
 fn nextNonCommentToken(token_tags: []const std.zig.Token.Tag, start: usize) ?usize {
     var index = start;
@@ -876,8 +964,59 @@ fn fieldAccessName(tree: *const std.zig.Ast, node: usize) ?[]const u8 {
     return normalizeIdentifier(tree.tokenSlice(datas[node].node_and_token[1]));
 }
 
-fn isTypeLikeAlias(public_name: []const u8, referenced_name: []const u8) bool {
-    return isTypeLikeName(normalizeIdentifier(public_name)) and isTypeLikeName(normalizeIdentifier(referenced_name));
+fn filePublicMemberImportsPath(file: *const FileInfo, member_name: []const u8, target_path: []const u8) bool {
+    const tags = file.tree.nodes.items(.tag);
+
+    for (file.tree.rootDecls()) |decl_idx| {
+        const idx = @intFromEnum(decl_idx);
+        if (idx >= tags.len) continue;
+        if (!isVarDeclTag(tags[idx])) continue;
+        if (publicVarDeclNamedImportsPath(&file.tree, @intCast(idx), file.path, member_name, target_path)) return true;
+    }
+    return false;
+}
+
+fn publicVarDeclNamedImportsPath(
+    tree: *const std.zig.Ast,
+    node_idx: u32,
+    importer_path: []const u8,
+    expected_name: []const u8,
+    target_path: []const u8,
+) bool {
+    const full = tree.fullVarDecl(@enumFromInt(node_idx)) orelse return false;
+    if (!isPubToken(tree, full.visib_token)) return false;
+
+    const name_token = full.ast.mut_token + 1;
+    if (name_token >= tree.tokens.len) return false;
+    if (tree.tokenTag(name_token) != .identifier) return false;
+    const name = normalizeIdentifier(tree.tokenSlice(name_token));
+    if (!std.mem.eql(u8, name, expected_name)) return false;
+
+    const init_node = full.ast.init_node.unwrap() orelse return false;
+    const import_path = importPathFromBuiltinCall(tree, @intFromEnum(init_node)) orelse return false;
+    return importMayResolveToPath(importer_path, import_path, target_path);
+}
+
+fn importMayResolveToPath(importer_path: []const u8, import_path: []const u8, target_path: []const u8) bool {
+    if (importResolvesToPath(importer_path, import_path, target_path)) return true;
+    return packageImportMayResolveToPath(import_path, target_path);
+}
+
+fn packageImportMayResolveToPath(import_path: []const u8, target_path: []const u8) bool {
+    if (std.mem.indexOfScalar(u8, import_path, '/') != null) return false;
+    if (std.mem.endsWith(u8, import_path, ".zig")) return false;
+
+    const basename = std.fs.path.basename(target_path);
+    if (!std.mem.endsWith(u8, basename, ".zig")) return false;
+    const stem = basename[0 .. basename.len - ".zig".len];
+    return std.mem.eql(u8, stem, import_path);
+}
+
+fn isReexportAlias(public_name: []const u8, referenced_name: []const u8) bool {
+    const normalized_public = normalizeIdentifier(public_name);
+    const normalized_referenced = normalizeIdentifier(referenced_name);
+    if (std.mem.eql(u8, normalized_public, normalized_referenced)) return true;
+    return isTypeLikeName(normalized_public) and isTypeLikeName(normalized_referenced);
 }
 
 fn isTypeLikeName(name: []const u8) bool {

--- a/src/project_unused_decl.zig
+++ b/src/project_unused_decl.zig
@@ -27,8 +27,10 @@ const FileInfo = struct {
     path: []const u8,
     content: [:0]const u8,
     tree: std.zig.Ast,
+    suppressions: suppression.SuppressionMap,
 
     fn deinit(self: *FileInfo, allocator: std.mem.Allocator) void {
+        self.suppressions.deinit();
         self.tree.deinit(allocator);
         allocator.free(self.content.ptr[0 .. self.content.len + 1]);
     }
@@ -61,6 +63,8 @@ pub fn analyze(
     }
 
     for (file_paths) |path| {
+        if (containsPath(files.items, path)) continue;
+
         const file = try std.fs.cwd().openFile(path, .{});
         defer file.close();
 
@@ -79,10 +83,14 @@ pub fn analyze(
         var tree = try std.zig.Ast.parse(allocator, content, .zig);
         errdefer tree.deinit(allocator);
 
+        var suppressions = try suppression.parseSuppressions(allocator, content);
+        errdefer suppressions.deinit();
+
         try files.append(allocator, .{
             .path = path,
             .content = content,
             .tree = tree,
+            .suppressions = suppressions,
         });
     }
 
@@ -103,9 +111,7 @@ pub fn analyze(
         defer source.deinit();
         const range = try source.byteRangeToSourceRange(decl.byte_offset, decl.byte_offset + decl.name.len);
 
-        var sup_map = try suppression.parseSuppressions(allocator, files.items[decl.file_index].content);
-        defer sup_map.deinit();
-        if (sup_map.isSuppressed(range.start.line, rule_id)) continue;
+        if (files.items[decl.file_index].suppressions.isSuppressed(range.start.line, rule_id)) continue;
 
         const message = try std.fmt.allocPrint(
             allocator,
@@ -114,7 +120,7 @@ pub fn analyze(
         );
         defer allocator.free(message);
 
-        const diag = try Diagnostic.init(
+        var diag = try Diagnostic.init(
             allocator,
             files.items[decl.file_index].path,
             rule_id,
@@ -122,8 +128,16 @@ pub fn analyze(
             message,
             range,
         );
+        errdefer diag.deinit(allocator);
         try diagnostics.append(allocator, diag);
     }
+}
+
+fn containsPath(files: []const FileInfo, path: []const u8) bool {
+    for (files) |file| {
+        if (std.mem.eql(u8, file.path, path)) return true;
+    }
+    return false;
 }
 
 fn collectPublicRootDecls(
@@ -157,7 +171,9 @@ fn collectPublicRootDecls(
                 mutable_decl.deinit(allocator);
                 continue;
             }
-            try decls.append(allocator, decl);
+            var mutable_decl = decl;
+            errdefer mutable_decl.deinit(allocator);
+            try decls.append(allocator, mutable_decl);
         }
     }
 }
@@ -297,18 +313,23 @@ fn classifyVarDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) Dec
 }
 
 fn isReferencedFromAnotherFile(files: []const FileInfo, decl: DeclInfo) bool {
+    const decl_file = files[decl.file_index];
     for (files, 0..) |*file, file_index| {
         if (file_index == decl.file_index) continue;
+        if (std.mem.eql(u8, file.path, decl_file.path)) continue;
         if (fileReferencesName(&file.tree, decl.normalized_name)) return true;
     }
     return false;
 }
 
 fn fileReferencesName(tree: *const std.zig.Ast, normalized_name: []const u8) bool {
-    const token_tags = tree.tokens.items(.tag);
-    for (token_tags, 0..) |tag, token_index| {
-        if (tag != .identifier) continue;
-        const slice = normalizeIdentifier(tree.tokenSlice(@intCast(token_index)));
+    const tags = tree.nodes.items(.tag);
+    const datas = tree.nodes.items(.data);
+
+    for (tags, 0..) |tag, node_index| {
+        if (tag != .field_access) continue;
+        const field_token = datas[node_index].node_and_token[1];
+        const slice = normalizeIdentifier(tree.tokenSlice(field_token));
         if (std.mem.eql(u8, slice, normalized_name)) return true;
     }
     return false;

--- a/src/project_unused_decl.zig
+++ b/src/project_unused_decl.zig
@@ -51,6 +51,109 @@ const DeclInfo = struct {
     }
 };
 
+const ProjectContext = struct {
+    allocator: std.mem.Allocator,
+    files: []const FileInfo,
+    api_roots: std.ArrayList(usize) = .empty,
+
+    fn init(allocator: std.mem.Allocator, files: []const FileInfo) ProjectContext {
+        return .{
+            .allocator = allocator,
+            .files = files,
+        };
+    }
+
+    fn deinit(self: *ProjectContext) void {
+        self.api_roots.deinit(self.allocator);
+    }
+
+    fn collectApiRoots(self: *ProjectContext) !void {
+        for (self.files, 0..) |*file, file_index| {
+            if (!std.mem.eql(u8, std.fs.path.basename(file.path), "build.zig")) continue;
+            try self.collectBuildRootSourceFiles(file_index);
+        }
+        try self.collectExternalBuildRootSourceFiles("build.zig");
+    }
+
+    fn isPublicApiFile(self: *const ProjectContext, file_index: usize) bool {
+        if (self.containsApiRoot(file_index)) return true;
+
+        const target_path = self.files[file_index].path;
+        for (self.api_roots.items) |root_index| {
+            if (filePubliclyImportsPath(self.files, &self.files[root_index], target_path)) return true;
+        }
+        return false;
+    }
+
+    fn containsApiRoot(self: *const ProjectContext, file_index: usize) bool {
+        for (self.api_roots.items) |root_index| {
+            if (root_index == file_index) return true;
+        }
+        return false;
+    }
+
+    fn appendApiRoot(self: *ProjectContext, file_index: usize) !void {
+        if (self.containsApiRoot(file_index)) return;
+        try self.api_roots.append(self.allocator, file_index);
+    }
+
+    fn collectBuildRootSourceFiles(self: *ProjectContext, build_file_index: usize) !void {
+        try self.collectBuildRootSourceFilesFromTree(&self.files[build_file_index].tree, self.files[build_file_index].path);
+    }
+
+    fn collectExternalBuildRootSourceFiles(self: *ProjectContext, build_path: []const u8) !void {
+        if (findFileIndexByPath(self.files, build_path) != null) return;
+
+        const file = std.fs.cwd().openFile(build_path, .{}) catch return;
+        defer file.close();
+
+        const max_size = 10 * 1024 * 1024;
+        // Sentinel needed for std.zig.Ast.parse; free accounts for sentinel byte below.
+        // zwanzig-disable-next-line: sentinel-alloc
+        const content = try file.readToEndAllocOptions(
+            self.allocator,
+            max_size,
+            null,
+            std.mem.Alignment.of(u8),
+            0,
+        );
+        defer self.allocator.free(content.ptr[0 .. content.len + 1]);
+
+        var tree = try std.zig.Ast.parse(self.allocator, content, .zig);
+        defer tree.deinit(self.allocator);
+
+        try self.collectBuildRootSourceFilesFromTree(&tree, build_path);
+    }
+
+    fn collectBuildRootSourceFilesFromTree(self: *ProjectContext, tree: *const std.zig.Ast, build_path: []const u8) !void {
+        const token_tags = tree.tokens.items(.tag);
+        for (token_tags, 0..) |_, token_index| {
+            if (!std.mem.eql(u8, tree.tokenSlice(@intCast(token_index)), "root_source_file")) continue;
+
+            var scan_token = token_index + 1;
+            var remaining: usize = 24;
+            while (scan_token < token_tags.len and remaining > 0) : ({
+                scan_token += 1;
+                remaining -= 1;
+            }) {
+                if (token_tags[scan_token] != .string_literal) continue;
+                const literal = tree.tokenSlice(@intCast(scan_token));
+                if (literal.len < 2) continue;
+                const root_path = literal[1 .. literal.len - 1];
+                if (resolveImportToFileIndex(self.files, build_path, root_path)) |root_index| {
+                    try self.appendApiRoot(root_index);
+                }
+                break;
+            }
+        }
+    }
+};
+
+const ResolvedType = struct {
+    file_index: usize,
+    type_name: ?[]const u8 = null,
+};
+
 pub fn analyze(
     allocator: std.mem.Allocator,
     file_paths: []const []const u8,
@@ -98,6 +201,10 @@ pub fn analyze(
 
     if (files.items.len < 2) return;
 
+    var project = ProjectContext.init(allocator, files.items);
+    defer project.deinit();
+    try project.collectApiRoots();
+
     var decls: std.ArrayList(DeclInfo) = .empty;
     defer {
         for (decls.items) |*decl| decl.deinit(allocator);
@@ -105,8 +212,8 @@ pub fn analyze(
     }
 
     for (files.items, 0..) |*file, file_index| {
-        if (isPublicApiFile(files.items, file.path)) continue;
-        try collectPublicRootDecls(allocator, &file.tree, file_index, &decls);
+        if (project.isPublicApiFile(file_index)) continue;
+        try collectPublicRootDecls(allocator, &file.tree, file.path, file_index, &decls);
     }
 
     const used = try collectProjectUsedDecls(allocator, files.items, decls.items);
@@ -141,15 +248,20 @@ pub fn analyze(
 }
 
 fn containsPath(files: []const FileInfo, path: []const u8) bool {
-    for (files) |file| {
-        if (std.mem.eql(u8, file.path, path)) return true;
+    return findFileIndexByPath(files, path) != null;
+}
+
+fn findFileIndexByPath(files: []const FileInfo, path: []const u8) ?usize {
+    for (files, 0..) |file, file_index| {
+        if (std.mem.eql(u8, file.path, path) or pathsEquivalent(file.path, path)) return file_index;
     }
-    return false;
+    return null;
 }
 
 fn collectPublicRootDecls(
     allocator: std.mem.Allocator,
     tree: *const std.zig.Ast,
+    path: []const u8,
     file_index: usize,
     decls: *std.ArrayList(DeclInfo),
 ) !void {
@@ -173,7 +285,7 @@ fn collectPublicRootDecls(
         };
 
         if (info) |decl| {
-            if (isSpecialName(decl.name)) {
+            if (isIgnoredPublicDecl(path, decl.name)) {
                 var mutable_decl = decl;
                 mutable_decl.deinit(allocator);
                 continue;
@@ -319,21 +431,7 @@ fn isPubToken(tree: *const std.zig.Ast, token: ?std.zig.Ast.TokenIndex) bool {
     return tree.tokenTag(tok) == .keyword_pub;
 }
 
-fn isPublicEntrypointPath(path: []const u8) bool {
-    return std.mem.eql(u8, path, "src/lib.zig") or std.mem.endsWith(u8, path, "/src/lib.zig");
-}
-
-fn isPublicApiFile(files: []const FileInfo, path: []const u8) bool {
-    if (isPublicEntrypointPath(path)) return true;
-
-    for (files) |*file| {
-        if (!isPublicEntrypointPath(file.path)) continue;
-        if (filePubliclyImportsPath(file, path)) return true;
-    }
-    return false;
-}
-
-fn filePubliclyImportsPath(file: *const FileInfo, target_path: []const u8) bool {
+fn filePubliclyImportsPath(files: []const FileInfo, file: *const FileInfo, target_path: []const u8) bool {
     const tags = file.tree.nodes.items(.tag);
 
     for (file.tree.rootDecls()) |decl_idx| {
@@ -342,7 +440,7 @@ fn filePubliclyImportsPath(file: *const FileInfo, target_path: []const u8) bool 
         if (!isVarDeclTag(tags[idx])) continue;
         if (publicVarDeclImportsPath(&file.tree, @intCast(idx), file.path, target_path)) return true;
     }
-    return publicUsingnamespaceImportsPath(&file.tree, file.path, target_path);
+    return publicUsingnamespaceImportsPath(files, &file.tree, file.path, target_path);
 }
 
 fn publicVarDeclImportsPath(
@@ -381,6 +479,24 @@ fn isVarDeclTag(tag: std.zig.Ast.Node.Tag) bool {
         => true,
         else => false,
     };
+}
+
+fn isBuiltinCallTag(tag: std.zig.Ast.Node.Tag) bool {
+    return switch (tag) {
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => true,
+        else => false,
+    };
+}
+
+fn isRootDeclNode(tree: *const std.zig.Ast, node_index: usize) bool {
+    for (tree.rootDecls()) |decl| {
+        if (@intFromEnum(decl) == node_index) return true;
+    }
+    return false;
 }
 
 fn isPublicAliasDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) bool {
@@ -461,7 +577,7 @@ fn collectProjectUsedDecls(
     @memset(used, false);
 
     for (decls, 0..) |decl, decl_index| {
-        if (isReferencedWithinDeclFile(files[decl.file_index], decl) or isReferencedFromAnotherFile(files, decl)) {
+        if (isReferencedWithinDeclFile(files, decl) or isReferencedFromAnotherFile(files, decl)) {
             used[decl_index] = true;
         }
     }
@@ -478,7 +594,8 @@ fn collectProjectUsedDecls(
     return used;
 }
 
-fn isReferencedWithinDeclFile(file: FileInfo, decl: DeclInfo) bool {
+fn isReferencedWithinDeclFile(files: []const FileInfo, decl: DeclInfo) bool {
+    const file = files[decl.file_index];
     const tags = file.tree.nodes.items(.tag);
     const main_tokens = file.tree.nodes.items(.main_token);
 
@@ -491,6 +608,8 @@ fn isReferencedWithinDeclFile(file: FileInfo, decl: DeclInfo) bool {
         if (std.mem.eql(u8, name, decl.normalized_name)) return true;
     }
 
+    if (fileReferencesDeclByTypedReceiver(files, decl.file_index, decl.file_index, decl.normalized_name)) return true;
+
     return false;
 }
 
@@ -499,7 +618,7 @@ fn isReferencedFromAnotherFile(files: []const FileInfo, decl: DeclInfo) bool {
     for (files, 0..) |*file, file_index| {
         if (file_index == decl.file_index) continue;
         if (std.mem.eql(u8, file.path, decl_file.path)) continue;
-        if (fileReferencesDecl(files, file, decl_file.path, decl.normalized_name)) return true;
+        if (fileReferencesDecl(files, file_index, decl.file_index, decl_file.path, decl.normalized_name)) return true;
     }
     return false;
 }
@@ -707,9 +826,17 @@ const PublicSurfaceScanner = struct {
     }
 };
 
-fn fileReferencesDecl(files: []const FileInfo, file: *const FileInfo, decl_path: []const u8, normalized_name: []const u8) bool {
+fn fileReferencesDecl(
+    files: []const FileInfo,
+    file_index: usize,
+    decl_file_index: usize,
+    decl_path: []const u8,
+    normalized_name: []const u8,
+) bool {
+    const file = &files[file_index];
     if (fileReferencesDeclByFieldAccess(files, &file.tree, file.path, decl_path, normalized_name)) return true;
-    if (fileUsingnamespaceImportsPath(&file.tree, file.path, decl_path) and fileReferencesBareName(&file.tree, normalized_name)) return true;
+    if (fileReferencesDeclByTypedReceiver(files, file_index, decl_file_index, normalized_name)) return true;
+    if (fileUsingnamespaceImportsPath(files, &file.tree, file.path, decl_path) and fileReferencesBareName(&file.tree, normalized_name)) return true;
     return false;
 }
 
@@ -734,6 +861,514 @@ fn fileReferencesDeclByFieldAccess(
     }
     return false;
 }
+
+fn fileReferencesDeclByTypedReceiver(
+    files: []const FileInfo,
+    file_index: usize,
+    decl_file_index: usize,
+    normalized_name: []const u8,
+) bool {
+    const file = &files[file_index];
+    const tree = &file.tree;
+    const tags = tree.nodes.items(.tag);
+    const datas = tree.nodes.items(.data);
+
+    var resolver = TypeResolver{
+        .files = files,
+        .file_index = file_index,
+    };
+
+    for (tags, 0..) |tag, node_index| {
+        switch (tag) {
+            .field_access => {
+                const field_access = datas[node_index].node_and_token;
+                const field_name = normalizeIdentifier(tree.tokenSlice(field_access[1]));
+                if (!std.mem.eql(u8, field_name, normalized_name)) continue;
+
+                const receiver = @intFromEnum(field_access[0]);
+                if (resolver.resolveExprType(receiver)) |receiver_type| {
+                    if (receiver_type.file_index == decl_file_index) return true;
+                }
+            },
+            .simple_var_decl,
+            .aligned_var_decl,
+            .global_var_decl,
+            .local_var_decl,
+            => {
+                const full = tree.fullVarDecl(@enumFromInt(node_index)) orelse continue;
+                if (resolver.varDeclInitializerReferencesExpectedTypeMethod(full, decl_file_index, normalized_name)) return true;
+            },
+            else => {},
+        }
+    }
+
+    return false;
+}
+
+const TypeResolver = struct {
+    files: []const FileInfo,
+    file_index: usize,
+
+    fn currentFile(self: TypeResolver) *const FileInfo {
+        return &self.files[self.file_index];
+    }
+
+    fn resolveExprType(self: TypeResolver, node: usize) ?ResolvedType {
+        const tree = &self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        switch (tags[node]) {
+            .identifier => {
+                const name = identifierName(tree, node) orelse return null;
+                return self.resolveNameType(name, node);
+            },
+            .field_access => {
+                const datas = tree.nodes.items(.data);
+                const field_access = datas[node].node_and_token;
+                const lhs = @intFromEnum(field_access[0]);
+                const member_name = normalizeIdentifier(tree.tokenSlice(field_access[1]));
+                const base_type = self.resolveExprType(lhs) orelse return null;
+                return self.resolveMemberType(base_type, member_name);
+            },
+            .call,
+            .call_comma,
+            .call_one,
+            .call_one_comma,
+            => return self.resolveCallType(@intCast(node)),
+            .struct_init,
+            .struct_init_comma,
+            .struct_init_one,
+            .struct_init_one_comma,
+            .struct_init_dot,
+            .struct_init_dot_comma,
+            .struct_init_dot_two,
+            .struct_init_dot_two_comma,
+            => return self.resolveStructInitType(@intCast(node)),
+            .builtin_call,
+            .builtin_call_comma,
+            .builtin_call_two,
+            .builtin_call_two_comma,
+            => return self.resolveBuiltinType(@intCast(node)),
+            else => return null,
+        }
+    }
+
+    fn resolveTypeNode(self: TypeResolver, node: usize) ?ResolvedType {
+        const tree = &self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        switch (tags[node]) {
+            .identifier => {
+                const name = identifierName(tree, node) orelse return null;
+                return self.resolveNameType(name, node);
+            },
+            .field_access => {
+                const datas = tree.nodes.items(.data);
+                const field_access = datas[node].node_and_token;
+                const lhs = @intFromEnum(field_access[0]);
+                const member_name = normalizeIdentifier(tree.tokenSlice(field_access[1]));
+                const base_type = self.resolveTypeNode(lhs) orelse self.resolveExprType(lhs) orelse return null;
+                return self.resolveMemberType(base_type, member_name);
+            },
+            .ptr_type,
+            .ptr_type_aligned,
+            .ptr_type_bit_range,
+            .ptr_type_sentinel,
+            => {
+                const ptr = tree.fullPtrType(@enumFromInt(node)) orelse return null;
+                return self.resolveTypeNode(@intFromEnum(ptr.ast.child_type));
+            },
+            .optional_type => return self.resolveTypeNode(@intFromEnum(tree.nodes.items(.data)[node].node)),
+            .error_union => return self.resolveTypeNode(@intFromEnum(tree.nodes.items(.data)[node].node_and_node[1])),
+            .builtin_call,
+            .builtin_call_comma,
+            .builtin_call_two,
+            .builtin_call_two_comma,
+            => return self.resolveBuiltinType(@intCast(node)),
+            else => return null,
+        }
+    }
+
+    fn resolveNameType(self: TypeResolver, name: []const u8, reference_node: usize) ?ResolvedType {
+        if (self.resolveNearestBindingType(name, reference_node)) |resolved| return resolved;
+        if (self.resolveNamedDeclType(self.file_index, name)) |resolved| return resolved;
+        if (std.mem.eql(u8, name, fileStem(self.currentFile().path))) {
+            return .{ .file_index = self.file_index };
+        }
+        return null;
+    }
+
+    fn resolveNearestBindingType(self: TypeResolver, name: []const u8, reference_node: usize) ?ResolvedType {
+        const tree = &self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        const reference_start = nodeStart(tree, reference_node) orelse return null;
+
+        var best_start: usize = 0;
+        var best_type: ?ResolvedType = null;
+
+        for (tags, 0..) |tag, node_index| {
+            switch (tag) {
+                .simple_var_decl,
+                .aligned_var_decl,
+                .global_var_decl,
+                .local_var_decl,
+                => {
+                    const full = tree.fullVarDecl(@enumFromInt(node_index)) orelse continue;
+                    const name_token = full.ast.mut_token + 1;
+                    if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
+                    const decl_name = normalizeIdentifier(tree.tokenSlice(name_token));
+                    if (!std.mem.eql(u8, decl_name, name)) continue;
+
+                    const start = tree.tokens.items(.start)[name_token];
+                    if (start > reference_start or start < best_start) continue;
+                    if (self.resolveVarDeclType(full, node_index, decl_name)) |resolved| {
+                        best_start = start;
+                        best_type = resolved;
+                    }
+                },
+                .fn_decl,
+                .fn_proto,
+                .fn_proto_simple,
+                .fn_proto_one,
+                .fn_proto_multi,
+                => {
+                    if (self.resolveFnParamBindingType(@intCast(node_index), name, reference_start, &best_start)) |resolved| {
+                        best_type = resolved;
+                    }
+                },
+                else => {},
+            }
+        }
+
+        return best_type;
+    }
+
+    fn resolveFnParamBindingType(
+        self: TypeResolver,
+        node: u32,
+        name: []const u8,
+        reference_start: usize,
+        best_start: *usize,
+    ) ?ResolvedType {
+        const tree = &self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        if (tags[node] == .fn_decl) {
+            const proto_node = @intFromEnum(tree.nodes.items(.data)[node].node_and_node[0]);
+            return self.resolveFnParamBindingType(@intCast(proto_node), name, reference_start, best_start);
+        }
+
+        var buffer: [1]std.zig.Ast.Node.Index = undefined;
+        const proto = switch (tags[node]) {
+            .fn_proto => tree.fnProto(@enumFromInt(node)),
+            .fn_proto_simple => tree.fnProtoSimple(&buffer, @enumFromInt(node)),
+            .fn_proto_one => tree.fnProtoOne(&buffer, @enumFromInt(node)),
+            .fn_proto_multi => tree.fnProtoMulti(@enumFromInt(node)),
+            else => return null,
+        };
+
+        var best_type: ?ResolvedType = null;
+        for (proto.ast.params) |param_node| {
+            const param_index = @intFromEnum(param_node);
+            if (param_index >= tags.len) continue;
+
+            if (isVarDeclTag(tags[param_index])) {
+                const full = tree.fullVarDecl(param_node) orelse continue;
+                const name_token = full.ast.mut_token + 1;
+                if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
+                const param_name = normalizeIdentifier(tree.tokenSlice(name_token));
+                if (!std.mem.eql(u8, param_name, name)) continue;
+
+                const start = tree.tokens.items(.start)[name_token];
+                if (start > reference_start or start < best_start.*) continue;
+                if (self.resolveVarDeclType(full, param_index, param_name)) |resolved| {
+                    best_start.* = start;
+                    best_type = resolved;
+                }
+                continue;
+            }
+
+            const name_token = paramNameTokenBeforeType(tree, param_index) orelse continue;
+            const param_name = normalizeIdentifier(tree.tokenSlice(@intCast(name_token)));
+            if (!std.mem.eql(u8, param_name, name)) continue;
+
+            const start = tree.tokens.items(.start)[name_token];
+            if (start > reference_start or start < best_start.*) continue;
+            if (self.resolveTypeNode(param_index)) |resolved| {
+                best_start.* = start;
+                best_type = resolved;
+            }
+        }
+        return best_type;
+    }
+
+    fn varDeclInitializerReferencesExpectedTypeMethod(
+        self: TypeResolver,
+        full: std.zig.Ast.full.VarDecl,
+        decl_file_index: usize,
+        method_name: []const u8,
+    ) bool {
+        const type_node = full.ast.type_node.unwrap() orelse return false;
+        const expected_type = self.resolveTypeNode(@intFromEnum(type_node)) orelse return false;
+        if (expected_type.file_index != decl_file_index) return false;
+        if (expected_type.type_name != null) return false;
+
+        const init_node = full.ast.init_node.unwrap() orelse return false;
+        return self.initializerReferencesExpectedTypeMethod(@intFromEnum(init_node), method_name);
+    }
+
+    fn resolveVarDeclType(
+        self: TypeResolver,
+        full: std.zig.Ast.full.VarDecl,
+        node_index: usize,
+        decl_name: []const u8,
+    ) ?ResolvedType {
+        if (full.ast.type_node.unwrap()) |type_node| {
+            if (self.resolveTypeNode(@intFromEnum(type_node))) |resolved| return resolved;
+        }
+
+        const init_node = full.ast.init_node.unwrap() orelse return null;
+        const init_index = @intFromEnum(init_node);
+        const tree = &self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (init_index >= tags.len) return null;
+        if (isBuiltinCallTag(tags[init_index])) {
+            return self.resolveBuiltinType(@intCast(init_index));
+        }
+        if (isContainerTag(tags[init_index])) {
+            return .{ .file_index = self.file_index, .type_name = decl_name };
+        }
+        if (isRootDeclNode(tree, node_index)) return null;
+        return self.resolveInitializerType(init_index);
+    }
+
+    fn resolveInitializerType(self: TypeResolver, node: usize) ?ResolvedType {
+        const tree = &self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        return switch (tags[node]) {
+            .call, .call_comma, .call_one, .call_one_comma => self.resolveCallType(@intCast(node)),
+            .@"try",
+            .address_of,
+            .deref,
+            .optional_type,
+            => self.resolveInitializerType(@intFromEnum(tree.nodes.items(.data)[node].node)),
+            .grouped_expression,
+            .unwrap_optional,
+            => self.resolveInitializerType(@intFromEnum(tree.nodes.items(.data)[node].node_and_token[0])),
+            .struct_init,
+            .struct_init_comma,
+            .struct_init_one,
+            .struct_init_one_comma,
+            .struct_init_dot,
+            .struct_init_dot_comma,
+            .struct_init_dot_two,
+            .struct_init_dot_two_comma,
+            => self.resolveStructInitType(@intCast(node)),
+            .builtin_call,
+            .builtin_call_comma,
+            .builtin_call_two,
+            .builtin_call_two_comma,
+            => self.resolveBuiltinType(@intCast(node)),
+            else => null,
+        };
+    }
+
+    fn initializerReferencesExpectedTypeMethod(
+        self: TypeResolver,
+        node: usize,
+        method_name: []const u8,
+    ) bool {
+        const tree = &self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return false;
+
+        return switch (tags[node]) {
+            .call,
+            .call_comma,
+            .call_one,
+            .call_one_comma,
+            => self.callUsesImplicitResultMethod(@intCast(node), method_name),
+            .@"try",
+            .address_of,
+            .deref,
+            .optional_type,
+            => self.initializerReferencesExpectedTypeMethod(@intFromEnum(tree.nodes.items(.data)[node].node), method_name),
+            .grouped_expression,
+            .unwrap_optional,
+            => self.initializerReferencesExpectedTypeMethod(@intFromEnum(tree.nodes.items(.data)[node].node_and_token[0]), method_name),
+            .@"catch" => self.initializerReferencesExpectedTypeMethod(@intFromEnum(tree.nodes.items(.data)[node].node_and_node[0]), method_name),
+            else => false,
+        };
+    }
+
+    fn callUsesImplicitResultMethod(self: TypeResolver, node: u32, method_name: []const u8) bool {
+        const tree = &self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return false;
+
+        var buffer: [1]std.zig.Ast.Node.Index = undefined;
+        const call = tree.fullCall(&buffer, @enumFromInt(node)) orelse return false;
+        const callee = @intFromEnum(call.ast.fn_expr);
+        if (callee >= tags.len or tags[callee] != .enum_literal) return false;
+
+        const token = tree.nodes.items(.main_token)[callee];
+        if (token >= tree.tokens.len) return false;
+        return std.mem.eql(u8, normalizeIdentifier(tree.tokenSlice(token)), method_name);
+    }
+
+    fn resolveCallType(self: TypeResolver, node: u32) ?ResolvedType {
+        const tree = &self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        var buffer: [1]std.zig.Ast.Node.Index = undefined;
+        const call = tree.fullCall(&buffer, @enumFromInt(node)) orelse return null;
+        const callee = @intFromEnum(call.ast.fn_expr);
+        if (callee >= tags.len) return null;
+        if (tags[callee] == .field_access) {
+            const lhs = @intFromEnum(tree.nodes.items(.data)[callee].node_and_token[0]);
+            return self.resolveTypeNode(lhs) orelse self.resolveExprType(lhs);
+        }
+        return null;
+    }
+
+    fn resolveStructInitType(self: TypeResolver, node: u32) ?ResolvedType {
+        const tree = &self.currentFile().tree;
+        var buffer: [2]std.zig.Ast.Node.Index = undefined;
+        const init = tree.fullStructInit(&buffer, @enumFromInt(node)) orelse return null;
+        const type_node = init.ast.type_expr.unwrap() orelse return null;
+        return self.resolveTypeNode(@intFromEnum(type_node));
+    }
+
+    fn resolveBuiltinType(self: TypeResolver, node: u32) ?ResolvedType {
+        const tree = &self.currentFile().tree;
+        if (importPathFromBuiltinCall(tree, node)) |import_path| {
+            if (resolveImportToFileIndex(self.files, self.currentFile().path, import_path)) |file_index| {
+                return .{ .file_index = file_index };
+            }
+        }
+        if (isThisBuiltinCall(tree, node)) {
+            return .{ .file_index = self.file_index };
+        }
+        return null;
+    }
+
+    fn resolveMemberType(self: TypeResolver, base_type: ResolvedType, member_name: []const u8) ?ResolvedType {
+        const member_resolver = TypeResolver{
+            .files = self.files,
+            .file_index = base_type.file_index,
+        };
+        if (member_resolver.resolveNamedDeclType(base_type.file_index, member_name)) |resolved| return resolved;
+        return member_resolver.resolveFieldType(base_type, member_name);
+    }
+
+    fn resolveNamedDeclType(self: TypeResolver, file_index: usize, name: []const u8) ?ResolvedType {
+        const file = &self.files[file_index];
+        const tree = &file.tree;
+        const tags = tree.nodes.items(.tag);
+
+        for (tree.rootDecls()) |decl_idx| {
+            const node_index = @intFromEnum(decl_idx);
+            if (node_index >= tags.len or !isVarDeclTag(tags[node_index])) continue;
+            const full = tree.fullVarDecl(decl_idx) orelse continue;
+            const name_token = full.ast.mut_token + 1;
+            if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
+            const decl_name = normalizeIdentifier(tree.tokenSlice(name_token));
+            if (!std.mem.eql(u8, decl_name, name)) continue;
+
+            const nested_resolver = TypeResolver{ .files = self.files, .file_index = file_index };
+            if (nested_resolver.resolveVarDeclType(full, node_index, decl_name)) |resolved| return resolved;
+        }
+        return null;
+    }
+
+    fn resolveFieldType(self: TypeResolver, base_type: ResolvedType, field_name: []const u8) ?ResolvedType {
+        if (base_type.type_name) |container_name| {
+            if (self.findNamedContainerNode(base_type.file_index, container_name)) |container_node| {
+                return self.resolveContainerFieldType(base_type.file_index, container_node, field_name);
+            }
+        }
+        return self.resolveRootFieldType(base_type.file_index, field_name);
+    }
+
+    fn findNamedContainerNode(self: TypeResolver, file_index: usize, name: []const u8) ?u32 {
+        const file = &self.files[file_index];
+        const tree = &file.tree;
+        const tags = tree.nodes.items(.tag);
+
+        for (tree.rootDecls()) |decl_idx| {
+            const node_index = @intFromEnum(decl_idx);
+            if (node_index >= tags.len or !isVarDeclTag(tags[node_index])) continue;
+            const full = tree.fullVarDecl(decl_idx) orelse continue;
+            const name_token = full.ast.mut_token + 1;
+            if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
+            if (!std.mem.eql(u8, normalizeIdentifier(tree.tokenSlice(name_token)), name)) continue;
+            const init_node = full.ast.init_node.unwrap() orelse continue;
+            const init_index = @intFromEnum(init_node);
+            if (init_index < tags.len and isContainerTag(tags[init_index])) return @intCast(init_index);
+        }
+        return null;
+    }
+
+    fn resolveRootFieldType(self: TypeResolver, file_index: usize, field_name: []const u8) ?ResolvedType {
+        const file = &self.files[file_index];
+        const tree = &file.tree;
+        const tags = tree.nodes.items(.tag);
+
+        for (tree.rootDecls()) |decl_idx| {
+            const node_index = @intFromEnum(decl_idx);
+            if (node_index >= tags.len) continue;
+            switch (tags[node_index]) {
+                .container_field,
+                .container_field_init,
+                .container_field_align,
+                => if (self.resolveContainerFieldNodeType(file_index, @intCast(node_index), field_name)) |resolved| return resolved,
+                else => {},
+            }
+        }
+        return null;
+    }
+
+    fn resolveContainerFieldType(self: TypeResolver, file_index: usize, container_node: u32, field_name: []const u8) ?ResolvedType {
+        const file = &self.files[file_index];
+        const tree = &file.tree;
+
+        var buffer: [2]std.zig.Ast.Node.Index = undefined;
+        const container = tree.fullContainerDecl(&buffer, @enumFromInt(container_node)) orelse return null;
+        for (container.ast.members) |member_node| {
+            const member = @intFromEnum(member_node);
+            if (self.resolveContainerFieldNodeType(file_index, @intCast(member), field_name)) |resolved| return resolved;
+        }
+        return null;
+    }
+
+    fn resolveContainerFieldNodeType(self: TypeResolver, file_index: usize, node: u32, field_name: []const u8) ?ResolvedType {
+        const file = &self.files[file_index];
+        const tree = &file.tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        const field = tree.fullContainerField(@enumFromInt(node)) orelse return null;
+        if (field.ast.tuple_like) return null;
+        const name_token = field.ast.main_token;
+        if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) return null;
+        if (!std.mem.eql(u8, normalizeIdentifier(tree.tokenSlice(name_token)), field_name)) return null;
+
+        const nested_resolver = TypeResolver{ .files = self.files, .file_index = file_index };
+        if (field.ast.type_expr.unwrap()) |type_node| {
+            return nested_resolver.resolveTypeNode(@intFromEnum(type_node));
+        }
+        if (field.ast.value_expr.unwrap()) |value_node| {
+            return nested_resolver.resolveInitializerType(@intFromEnum(value_node));
+        }
+        return null;
+    }
+};
 
 fn fileReferencesBareName(tree: *const std.zig.Ast, normalized_name: []const u8) bool {
     const tags = tree.nodes.items(.tag);
@@ -812,6 +1447,7 @@ fn importAliasResolvesToPath(
 }
 
 fn fileUsingnamespaceImportsPath(
+    files: []const FileInfo,
     tree: *const std.zig.Ast,
     importer_path: []const u8,
     target_path: []const u8,
@@ -826,12 +1462,16 @@ fn fileUsingnamespaceImportsPath(
 
         const import_path = importPathFromBuiltinToken(tree, import_token) orelse continue;
         if (importMayResolveToPath(importer_path, import_path, target_path)) return true;
+        if (resolveImportToFileIndex(files, importer_path, import_path)) |file_index| {
+            if (filePubliclyImportsPath(files, &files[file_index], target_path)) return true;
+        }
     }
 
     return false;
 }
 
 fn publicUsingnamespaceImportsPath(
+    files: []const FileInfo,
     tree: *const std.zig.Ast,
     importer_path: []const u8,
     target_path: []const u8,
@@ -849,6 +1489,9 @@ fn publicUsingnamespaceImportsPath(
 
         const import_path = importPathFromBuiltinToken(tree, import_token) orelse continue;
         if (importMayResolveToPath(importer_path, import_path, target_path)) return true;
+        if (resolveImportToFileIndex(files, importer_path, import_path)) |file_index| {
+            if (filePubliclyImportsPath(files, &files[file_index], target_path)) return true;
+        }
     }
 
     return false;
@@ -949,6 +1592,18 @@ fn prevNonCommentToken(token_tags: []const std.zig.Token.Tag, start: usize) ?usi
     }
 }
 
+fn paramNameTokenBeforeType(tree: *const std.zig.Ast, type_node: usize) ?usize {
+    const main_tokens = tree.nodes.items(.main_token);
+    if (type_node >= main_tokens.len) return null;
+    const token_tags = tree.tokens.items(.tag);
+    const type_token = main_tokens[type_node];
+    const colon_token = prevNonCommentToken(token_tags, type_token) orelse return null;
+    if (token_tags[colon_token] != .colon) return null;
+    const name_token = prevNonCommentToken(token_tags, colon_token) orelse return null;
+    if (token_tags[name_token] != .identifier) return null;
+    return name_token;
+}
+
 fn identifierName(tree: *const std.zig.Ast, node: usize) ?[]const u8 {
     const tags = tree.nodes.items(.tag);
     if (node >= tags.len or tags[node] != .identifier) return null;
@@ -1000,6 +1655,13 @@ fn publicVarDeclNamedImportsPath(
 fn importMayResolveToPath(importer_path: []const u8, import_path: []const u8, target_path: []const u8) bool {
     if (importResolvesToPath(importer_path, import_path, target_path)) return true;
     return packageImportMayResolveToPath(import_path, target_path);
+}
+
+fn resolveImportToFileIndex(files: []const FileInfo, importer_path: []const u8, import_path: []const u8) ?usize {
+    for (files, 0..) |file, file_index| {
+        if (importMayResolveToPath(importer_path, import_path, file.path)) return file_index;
+    }
+    return null;
 }
 
 fn packageImportMayResolveToPath(import_path: []const u8, target_path: []const u8) bool {
@@ -1075,6 +1737,33 @@ fn normalizeIdentifier(ident: []const u8) []const u8 {
     return ident;
 }
 
+fn nodeStart(tree: *const std.zig.Ast, node: usize) ?usize {
+    const main_tokens = tree.nodes.items(.main_token);
+    if (node >= main_tokens.len) return null;
+    const token = main_tokens[node];
+    if (token >= tree.tokens.len) return null;
+    return tree.tokens.items(.start)[token];
+}
+
+fn isThisBuiltinCall(tree: *const std.zig.Ast, node: usize) bool {
+    const main_tokens = tree.nodes.items(.main_token);
+    if (node >= main_tokens.len) return false;
+    const token = main_tokens[node];
+    if (token >= tree.tokens.len) return false;
+    return std.mem.eql(u8, tree.tokenSlice(token), "@This");
+}
+
+fn fileStem(path: []const u8) []const u8 {
+    const basename = std.fs.path.basename(path);
+    if (std.mem.endsWith(u8, basename, ".zig")) return basename[0 .. basename.len - ".zig".len];
+    return basename;
+}
+
+fn isIgnoredPublicDecl(path: []const u8, name: []const u8) bool {
+    if (isSpecialName(name)) return true;
+    return std.mem.eql(u8, std.fs.path.basename(path), "build.zig") and std.mem.eql(u8, name, "build");
+}
+
 fn isSpecialName(name: []const u8) bool {
     if (name.len > 0 and name[0] == '_') return true;
     if (std.mem.eql(u8, name, "main")) return true;
@@ -1129,9 +1818,9 @@ fn isContainerTag(tag: std.zig.Ast.Node.Tag) bool {
     };
 }
 
-test "project unused declarations recognize public entrypoint path" {
-    try std.testing.expect(isPublicEntrypointPath("src/lib.zig"));
-    try std.testing.expect(isPublicEntrypointPath("workspace/src/lib.zig"));
-    try std.testing.expect(!isPublicEntrypointPath("src/main.zig"));
-    try std.testing.expect(!isPublicEntrypointPath("test/fixtures/project_unused_decl/lib.zig"));
+test "project unused declarations ignore Zig build entrypoint" {
+    try std.testing.expect(isIgnoredPublicDecl("build.zig", "build"));
+    try std.testing.expect(isIgnoredPublicDecl("workspace/build.zig", "build"));
+    try std.testing.expect(!isIgnoredPublicDecl("src/lib.zig", "build"));
+    try std.testing.expect(!isIgnoredPublicDecl("build.zig", "helper"));
 }

--- a/src/project_unused_decl.zig
+++ b/src/project_unused_decl.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const ast_walk = @import("ast_walk.zig");
 const Diagnostic = @import("diagnostic.zig").Diagnostic;
 const Source = @import("source.zig").Source;
 const suppression = @import("suppression.zig");
@@ -38,6 +39,7 @@ const FileInfo = struct {
 
 const DeclInfo = struct {
     file_index: usize,
+    node_index: u32,
     name: []const u8,
     normalized_name: []const u8,
     byte_offset: usize,
@@ -105,9 +107,11 @@ pub fn analyze(
         try collectPublicRootDecls(allocator, &file.tree, file_index, &decls);
     }
 
-    for (decls.items) |decl| {
-        if (isReferencedFromAnotherFile(files.items, decl)) continue;
+    const used = try collectProjectUsedDecls(allocator, files.items, decls.items);
+    defer allocator.free(used);
 
+    for (decls.items, 0..) |decl, decl_index| {
+        if (used[decl_index]) continue;
         var source = Source.init(allocator, files.items[decl.file_index].path, files.items[decl.file_index].content);
         defer source.deinit();
         const range = try source.byteRangeToSourceRange(decl.byte_offset, decl.byte_offset + decl.name.len);
@@ -200,6 +204,7 @@ fn extractPublicVarDecl(
     return try makeDeclInfo(
         allocator,
         file_index,
+        node_idx,
         name,
         token_starts[name_token],
         classifyVarDecl(tree, full),
@@ -226,6 +231,7 @@ fn extractPublicFnDecl(
         .fn_proto => extractPublicFnProto(
             allocator,
             tree,
+            node_idx,
             tree.fnProto(@enumFromInt(node_idx)),
             token_starts,
             file_index,
@@ -233,6 +239,7 @@ fn extractPublicFnDecl(
         .fn_proto_simple => extractPublicFnProto(
             allocator,
             tree,
+            node_idx,
             tree.fnProtoSimple(&buffer, @enumFromInt(node_idx)),
             token_starts,
             file_index,
@@ -240,6 +247,7 @@ fn extractPublicFnDecl(
         .fn_proto_one => extractPublicFnProto(
             allocator,
             tree,
+            node_idx,
             tree.fnProtoOne(&buffer, @enumFromInt(node_idx)),
             token_starts,
             file_index,
@@ -247,6 +255,7 @@ fn extractPublicFnDecl(
         .fn_proto_multi => extractPublicFnProto(
             allocator,
             tree,
+            node_idx,
             tree.fnProtoMulti(@enumFromInt(node_idx)),
             token_starts,
             file_index,
@@ -258,6 +267,7 @@ fn extractPublicFnDecl(
 fn extractPublicFnProto(
     allocator: std.mem.Allocator,
     tree: *const std.zig.Ast,
+    node_idx: u32,
     proto: std.zig.Ast.full.FnProto,
     token_starts: []const u32,
     file_index: usize,
@@ -274,6 +284,7 @@ fn extractPublicFnProto(
     return try makeDeclInfo(
         allocator,
         file_index,
+        node_idx,
         tree.tokenSlice(name_token),
         token_starts[name_token],
         .function,
@@ -283,6 +294,7 @@ fn extractPublicFnProto(
 fn makeDeclInfo(
     allocator: std.mem.Allocator,
     file_index: usize,
+    node_index: u32,
     name: []const u8,
     byte_offset: usize,
     kind: DeclKind,
@@ -292,6 +304,7 @@ fn makeDeclInfo(
     const normalized_copy = try allocator.dupe(u8, normalizeIdentifier(name));
     return .{
         .file_index = file_index,
+        .node_index = node_index,
         .name = name_copy,
         .normalized_name = normalized_copy,
         .byte_offset = byte_offset,
@@ -433,6 +446,30 @@ fn classifyVarDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) Dec
     return .declaration;
 }
 
+fn collectProjectUsedDecls(
+    allocator: std.mem.Allocator,
+    files: []const FileInfo,
+    decls: []const DeclInfo,
+) ![]bool {
+    const used = try allocator.alloc(bool, decls.len);
+    @memset(used, false);
+
+    for (decls, 0..) |decl, decl_index| {
+        if (isReferencedFromAnotherFile(files, decl)) used[decl_index] = true;
+    }
+
+    var changed = true;
+    while (changed) {
+        changed = false;
+        for (decls, 0..) |decl, decl_index| {
+            if (!used[decl_index]) continue;
+            if (try markPublicSurfaceReferences(files, decls, used, decl)) changed = true;
+        }
+    }
+
+    return used;
+}
+
 fn isReferencedFromAnotherFile(files: []const FileInfo, decl: DeclInfo) bool {
     const decl_file = files[decl.file_index];
     for (files, 0..) |*file, file_index| {
@@ -442,6 +479,209 @@ fn isReferencedFromAnotherFile(files: []const FileInfo, decl: DeclInfo) bool {
     }
     return false;
 }
+
+fn markPublicSurfaceReferences(
+    files: []const FileInfo,
+    decls: []const DeclInfo,
+    used: []bool,
+    decl: DeclInfo,
+) !bool {
+    const file = &files[decl.file_index];
+    var scanner = PublicSurfaceScanner{
+        .tree = &file.tree,
+        .decls = decls,
+        .used = used,
+        .file_index = decl.file_index,
+    };
+    try scanner.scanDecl(decl.node_index);
+    return scanner.changed;
+}
+
+const PublicSurfaceScanner = struct {
+    tree: *const std.zig.Ast,
+    decls: []const DeclInfo,
+    used: []bool,
+    file_index: usize,
+    changed: bool = false,
+    stop: bool = false,
+
+    fn scanDecl(self: *PublicSurfaceScanner, node: u32) anyerror!void {
+        const tags = self.tree.nodes.items(.tag);
+        if (node >= tags.len) return;
+
+        switch (tags[node]) {
+            .simple_var_decl,
+            .aligned_var_decl,
+            .global_var_decl,
+            => try self.scanVarDeclSurface(node),
+            .fn_decl => {
+                const data = self.tree.nodes.items(.data)[node];
+                try self.scanFnProto(@intFromEnum(data.node_and_node[0]));
+            },
+            .fn_proto,
+            .fn_proto_simple,
+            .fn_proto_one,
+            .fn_proto_multi,
+            => try self.scanFnProto(node),
+            else => {},
+        }
+    }
+
+    fn scanVarDeclSurface(self: *PublicSurfaceScanner, node: u32) anyerror!void {
+        const full = self.tree.fullVarDecl(@enumFromInt(node)) orelse return;
+        try self.scanOptionalNode(full.ast.type_node);
+
+        const init_node = full.ast.init_node.unwrap() orelse return;
+        const init_idx = @intFromEnum(init_node);
+        const tags = self.tree.nodes.items(.tag);
+        if (init_idx < tags.len and isContainerTag(tags[init_idx])) {
+            try self.scanContainerSurface(init_idx);
+        } else {
+            try self.scanNode(init_idx);
+        }
+    }
+
+    fn scanFnProto(self: *PublicSurfaceScanner, node: u32) anyerror!void {
+        const tags = self.tree.nodes.items(.tag);
+        if (node >= tags.len) return;
+
+        var buffer: [1]std.zig.Ast.Node.Index = undefined;
+        const proto = switch (tags[node]) {
+            .fn_proto => self.tree.fnProto(@enumFromInt(node)),
+            .fn_proto_simple => self.tree.fnProtoSimple(&buffer, @enumFromInt(node)),
+            .fn_proto_one => self.tree.fnProtoOne(&buffer, @enumFromInt(node)),
+            .fn_proto_multi => self.tree.fnProtoMulti(@enumFromInt(node)),
+            else => return,
+        };
+
+        for (proto.ast.params) |param| try self.scanParam(@intFromEnum(param));
+        try self.scanOptionalNode(proto.ast.return_type);
+        try self.scanOptionalNode(proto.ast.align_expr);
+        try self.scanOptionalNode(proto.ast.addrspace_expr);
+        try self.scanOptionalNode(proto.ast.section_expr);
+        try self.scanOptionalNode(proto.ast.callconv_expr);
+    }
+
+    fn scanParam(self: *PublicSurfaceScanner, node: u32) anyerror!void {
+        const tags = self.tree.nodes.items(.tag);
+        if (node >= tags.len) return;
+
+        if (isVarDeclTag(tags[node])) {
+            const full = self.tree.fullVarDecl(@enumFromInt(node)) orelse return;
+            try self.scanOptionalNode(full.ast.type_node);
+            return;
+        }
+
+        try self.scanNode(node);
+    }
+
+    fn scanContainerSurface(self: *PublicSurfaceScanner, node: u32) anyerror!void {
+        const tags = self.tree.nodes.items(.tag);
+        if (node >= tags.len) return;
+
+        switch (tags[node]) {
+            .container_decl,
+            .container_decl_trailing,
+            => try self.scanContainerDeclComponents(self.tree.containerDecl(@enumFromInt(node))),
+            .container_decl_two,
+            .container_decl_two_trailing,
+            => {
+                var buffer: [2]std.zig.Ast.Node.Index = undefined;
+                try self.scanContainerDeclComponents(self.tree.containerDeclTwo(&buffer, @enumFromInt(node)));
+            },
+            .container_decl_arg,
+            .container_decl_arg_trailing,
+            => try self.scanContainerDeclComponents(self.tree.containerDeclArg(@enumFromInt(node))),
+            .tagged_union,
+            .tagged_union_trailing,
+            => try self.scanContainerDeclComponents(self.tree.taggedUnion(@enumFromInt(node))),
+            .tagged_union_enum_tag,
+            .tagged_union_enum_tag_trailing,
+            => try self.scanContainerDeclComponents(self.tree.taggedUnionEnumTag(@enumFromInt(node))),
+            .tagged_union_two,
+            .tagged_union_two_trailing,
+            => {
+                var buffer: [2]std.zig.Ast.Node.Index = undefined;
+                try self.scanContainerDeclComponents(self.tree.taggedUnionTwo(&buffer, @enumFromInt(node)));
+            },
+            else => {},
+        }
+    }
+
+    fn scanContainerDeclComponents(
+        self: *PublicSurfaceScanner,
+        container: std.zig.Ast.full.ContainerDecl,
+    ) anyerror!void {
+        if (container.ast.arg.unwrap()) |arg_node| try self.scanNode(@intFromEnum(arg_node));
+
+        const tags = self.tree.nodes.items(.tag);
+        for (container.ast.members) |member_node| {
+            const member = @intFromEnum(member_node);
+            if (member >= tags.len) continue;
+
+            switch (tags[member]) {
+                .container_field,
+                .container_field_init,
+                .container_field_align,
+                => try self.scanContainerField(member),
+                .simple_var_decl,
+                .aligned_var_decl,
+                .global_var_decl,
+                => {
+                    const full = self.tree.fullVarDecl(@enumFromInt(member)) orelse continue;
+                    if (isPubToken(self.tree, full.visib_token)) try self.scanVarDeclSurface(member);
+                },
+                .fn_decl,
+                .fn_proto,
+                .fn_proto_simple,
+                .fn_proto_one,
+                .fn_proto_multi,
+                => if (isPublicFnDecl(self.tree, member)) try self.scanDecl(member),
+                else => {},
+            }
+        }
+    }
+
+    fn scanContainerField(self: *PublicSurfaceScanner, node: u32) anyerror!void {
+        const field = self.tree.fullContainerField(@enumFromInt(node)) orelse return;
+        try self.scanOptionalNode(field.ast.type_expr);
+        try self.scanOptionalNode(field.ast.value_expr);
+        try self.scanOptionalNode(field.ast.align_expr);
+    }
+
+    fn scanOptionalNode(self: *PublicSurfaceScanner, node_opt: std.zig.Ast.Node.OptionalIndex) anyerror!void {
+        if (node_opt.unwrap()) |node| try self.scanNode(@intFromEnum(node));
+    }
+
+    fn scanNode(self: *PublicSurfaceScanner, node: u32) anyerror!void {
+        try ast_walk.walk(PublicSurfaceScanner, self.tree, node, self);
+    }
+
+    pub fn visit(
+        self: *PublicSurfaceScanner,
+        tree: *const std.zig.Ast,
+        node: u32,
+        tag: std.zig.Ast.Node.Tag,
+    ) anyerror!void {
+        if (tag != .identifier) return;
+
+        const main_tokens = tree.nodes.items(.main_token);
+        if (node >= main_tokens.len) return;
+        self.markIdentifier(tree.tokenSlice(main_tokens[node]));
+    }
+
+    fn markIdentifier(self: *PublicSurfaceScanner, identifier: []const u8) void {
+        const normalized = normalizeIdentifier(identifier);
+        for (self.decls, 0..) |candidate, candidate_index| {
+            if (candidate.file_index != self.file_index) continue;
+            if (self.used[candidate_index]) continue;
+            if (!std.mem.eql(u8, candidate.normalized_name, normalized)) continue;
+
+            self.used[candidate_index] = true;
+            self.changed = true;
+        }
+    }
+};
 
 fn fileReferencesName(tree: *const std.zig.Ast, normalized_name: []const u8) bool {
     const tags = tree.nodes.items(.tag);
@@ -469,6 +709,33 @@ fn isSpecialName(name: []const u8) bool {
     if (std.mem.eql(u8, name, "panic")) return true;
     if (std.mem.eql(u8, name, "std_options")) return true;
     return false;
+}
+
+fn isPublicFnDecl(tree: *const std.zig.Ast, node: u32) bool {
+    const tags = tree.nodes.items(.tag);
+    if (node >= tags.len) return false;
+
+    var buffer: [1]std.zig.Ast.Node.Index = undefined;
+    const proto = switch (tags[node]) {
+        .fn_decl => blk: {
+            const data = tree.nodes.items(.data)[node];
+            const proto_node = @intFromEnum(data.node_and_node[0]);
+            break :blk switch (tags[proto_node]) {
+                .fn_proto => tree.fnProto(@enumFromInt(proto_node)),
+                .fn_proto_simple => tree.fnProtoSimple(&buffer, @enumFromInt(proto_node)),
+                .fn_proto_one => tree.fnProtoOne(&buffer, @enumFromInt(proto_node)),
+                .fn_proto_multi => tree.fnProtoMulti(@enumFromInt(proto_node)),
+                else => return false,
+            };
+        },
+        .fn_proto => tree.fnProto(@enumFromInt(node)),
+        .fn_proto_simple => tree.fnProtoSimple(&buffer, @enumFromInt(node)),
+        .fn_proto_one => tree.fnProtoOne(&buffer, @enumFromInt(node)),
+        .fn_proto_multi => tree.fnProtoMulti(@enumFromInt(node)),
+        else => return false,
+    };
+
+    return isPubToken(tree, proto.visib_token);
 }
 
 fn isContainerTag(tag: std.zig.Ast.Node.Tag) bool {

--- a/src/project_unused_decl.zig
+++ b/src/project_unused_decl.zig
@@ -195,7 +195,7 @@ fn extractPublicVarDecl(
     if (token_tags[name_token] != .identifier) return null;
 
     const name = tree.tokenSlice(name_token);
-    return makeDeclInfo(
+    return try makeDeclInfo(
         allocator,
         file_index,
         name,
@@ -269,7 +269,7 @@ fn extractPublicFnProto(
     const name_token = proto.name_token orelse return null;
     if (tree.tokenTag(name_token) != .identifier) return null;
 
-    return makeDeclInfo(
+    return try makeDeclInfo(
         allocator,
         file_index,
         tree.tokenSlice(name_token),

--- a/src/project_unused_decl.zig
+++ b/src/project_unused_decl.zig
@@ -96,6 +96,8 @@ pub fn analyze(
         });
     }
 
+    if (files.items.len < 2) return;
+
     var decls: std.ArrayList(DeclInfo) = .empty;
     defer {
         for (decls.items) |*decl| decl.deinit(allocator);
@@ -340,7 +342,7 @@ fn filePubliclyImportsPath(file: *const FileInfo, target_path: []const u8) bool 
         if (!isVarDeclTag(tags[idx])) continue;
         if (publicVarDeclImportsPath(&file.tree, @intCast(idx), file.path, target_path)) return true;
     }
-    return false;
+    return publicUsingnamespaceImportsPath(&file.tree, file.path, target_path);
 }
 
 fn publicVarDeclImportsPath(
@@ -389,10 +391,13 @@ fn isPublicAliasDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) b
     const tags = tree.nodes.items(.tag);
     if (init_idx >= tags.len) return false;
 
+    const name_token = full.ast.mut_token + 1;
+    if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) return false;
+    const public_name = tree.tokenSlice(name_token);
+
     return switch (tags[init_idx]) {
-        .identifier,
-        .field_access,
-        => true,
+        .identifier => isTypeLikeAlias(public_name, identifierName(tree, init_idx) orelse return false),
+        .field_access => isTypeLikeAlias(public_name, fieldAccessName(tree, init_idx) orelse return false),
         .builtin_call,
         .builtin_call_comma,
         .builtin_call_two,
@@ -429,16 +434,17 @@ fn importResolvesToPath(importer_path: []const u8, import_path: []const u8, targ
     if (std.mem.eql(u8, import_path, target_path)) return true;
 
     const importer_dir = std.fs.path.dirname(importer_path) orelse "";
-    if (importer_dir.len == 0) return std.mem.eql(u8, import_path, target_path);
+    if (importer_dir.len == 0) return pathsEquivalent(import_path, target_path);
 
     var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
     const resolved = std.fmt.bufPrint(&resolved_buf, "{s}/{s}", .{ importer_dir, import_path }) catch return false;
-    return std.mem.eql(u8, resolved, target_path);
+    return pathsEquivalent(resolved, target_path);
 }
 
 fn classifyVarDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) DeclKind {
     if (full.ast.init_node.unwrap()) |init_node| {
-        if (isContainerTag(tree.nodes.items(.tag)[@intFromEnum(init_node)])) return .type_decl;
+        const tag = tree.nodes.items(.tag)[@intFromEnum(init_node)];
+        if (isContainerTag(tag) or tag == .error_set_decl) return .type_decl;
     }
     const mut_tag = tree.tokenTag(full.ast.mut_token);
     if (mut_tag == .keyword_const) return .constant;
@@ -475,7 +481,7 @@ fn isReferencedFromAnotherFile(files: []const FileInfo, decl: DeclInfo) bool {
     for (files, 0..) |*file, file_index| {
         if (file_index == decl.file_index) continue;
         if (std.mem.eql(u8, file.path, decl_file.path)) continue;
-        if (fileReferencesName(&file.tree, decl.normalized_name)) return true;
+        if (fileReferencesDecl(file, decl_file.path, decl.normalized_name)) return true;
     }
     return false;
 }
@@ -683,7 +689,18 @@ const PublicSurfaceScanner = struct {
     }
 };
 
-fn fileReferencesName(tree: *const std.zig.Ast, normalized_name: []const u8) bool {
+fn fileReferencesDecl(file: *const FileInfo, decl_path: []const u8, normalized_name: []const u8) bool {
+    if (fileReferencesDeclByFieldAccess(&file.tree, file.path, decl_path, normalized_name)) return true;
+    if (fileUsingnamespaceImportsPath(&file.tree, file.path, decl_path) and fileReferencesBareName(&file.tree, normalized_name)) return true;
+    return false;
+}
+
+fn fileReferencesDeclByFieldAccess(
+    tree: *const std.zig.Ast,
+    importer_path: []const u8,
+    decl_path: []const u8,
+    normalized_name: []const u8,
+) bool {
     const tags = tree.nodes.items(.tag);
     const datas = tree.nodes.items(.data);
 
@@ -691,9 +708,225 @@ fn fileReferencesName(tree: *const std.zig.Ast, normalized_name: []const u8) boo
         if (tag != .field_access) continue;
         const field_token = datas[node_index].node_and_token[1];
         const slice = normalizeIdentifier(tree.tokenSlice(field_token));
-        if (std.mem.eql(u8, slice, normalized_name)) return true;
+        if (!std.mem.eql(u8, slice, normalized_name)) continue;
+
+        const lhs = @intFromEnum(datas[node_index].node_and_token[0]);
+        if (nodeImportsPath(tree, lhs, importer_path, decl_path)) return true;
     }
     return false;
+}
+
+fn fileReferencesBareName(tree: *const std.zig.Ast, normalized_name: []const u8) bool {
+    const tags = tree.nodes.items(.tag);
+    const main_tokens = tree.nodes.items(.main_token);
+
+    for (tags, 0..) |tag, node_index| {
+        if (tag != .identifier) continue;
+        if (node_index >= main_tokens.len) continue;
+        const name = normalizeIdentifier(tree.tokenSlice(main_tokens[node_index]));
+        if (std.mem.eql(u8, name, normalized_name)) return true;
+    }
+    return false;
+}
+
+fn nodeImportsPath(
+    tree: *const std.zig.Ast,
+    node: usize,
+    importer_path: []const u8,
+    target_path: []const u8,
+) bool {
+    const tags = tree.nodes.items(.tag);
+    if (node >= tags.len) return false;
+
+    switch (tags[node]) {
+        .identifier => {
+            const name = identifierName(tree, node) orelse return false;
+            return importAliasResolvesToPath(tree, importer_path, name, target_path);
+        },
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => {
+            const import_path = importPathFromBuiltinCall(tree, node) orelse return false;
+            return importResolvesToPath(importer_path, import_path, target_path);
+        },
+        else => return false,
+    }
+}
+
+fn importAliasResolvesToPath(
+    tree: *const std.zig.Ast,
+    importer_path: []const u8,
+    alias_name: []const u8,
+    target_path: []const u8,
+) bool {
+    const tags = tree.nodes.items(.tag);
+
+    for (tags, 0..) |tag, node_index| {
+        if (!isVarDeclTag(tag)) continue;
+        const full = tree.fullVarDecl(@enumFromInt(node_index)) orelse continue;
+        const name_token = full.ast.mut_token + 1;
+        if (name_token >= tree.tokens.len) continue;
+        if (tree.tokenTag(name_token) != .identifier) continue;
+
+        const name = normalizeIdentifier(tree.tokenSlice(name_token));
+        if (!std.mem.eql(u8, name, alias_name)) continue;
+
+        const init_node = full.ast.init_node.unwrap() orelse continue;
+        const import_path = importPathFromBuiltinCall(tree, @intFromEnum(init_node)) orelse continue;
+        if (importResolvesToPath(importer_path, import_path, target_path)) return true;
+    }
+
+    return false;
+}
+
+fn fileUsingnamespaceImportsPath(
+    tree: *const std.zig.Ast,
+    importer_path: []const u8,
+    target_path: []const u8,
+) bool {
+    const token_tags = tree.tokens.items(.tag);
+
+    for (token_tags, 0..) |_, token_index| {
+        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(token_index)), "usingnamespace")) continue;
+
+        const import_token = nextNonCommentToken(token_tags, token_index + 1) orelse continue;
+        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(import_token)), "@import")) continue;
+
+        const import_path = importPathFromBuiltinToken(tree, import_token) orelse continue;
+        if (importResolvesToPath(importer_path, import_path, target_path)) return true;
+    }
+
+    return false;
+}
+
+fn publicUsingnamespaceImportsPath(
+    tree: *const std.zig.Ast,
+    importer_path: []const u8,
+    target_path: []const u8,
+) bool {
+    const token_tags = tree.tokens.items(.tag);
+
+    for (token_tags, 0..) |_, token_index| {
+        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(token_index)), "usingnamespace")) continue;
+
+        const pub_token = prevNonCommentToken(token_tags, token_index) orelse continue;
+        if (tree.tokenTag(@intCast(pub_token)) != .keyword_pub) continue;
+
+        const import_token = nextNonCommentToken(token_tags, token_index + 1) orelse continue;
+        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(import_token)), "@import")) continue;
+
+        const import_path = importPathFromBuiltinToken(tree, import_token) orelse continue;
+        if (importResolvesToPath(importer_path, import_path, target_path)) return true;
+    }
+
+    return false;
+}
+
+fn importPathFromBuiltinToken(tree: *const std.zig.Ast, token: usize) ?[]const u8 {
+    const token_tags = tree.tokens.items(.tag);
+    const l_paren = nextNonCommentToken(token_tags, token + 1) orelse return null;
+    if (token_tags[l_paren] != .l_paren) return null;
+
+    const string_token = nextNonCommentToken(token_tags, l_paren + 1) orelse return null;
+    if (token_tags[string_token] != .string_literal) return null;
+
+    const literal = tree.tokenSlice(@intCast(string_token));
+    if (literal.len < 2) return null;
+    return literal[1 .. literal.len - 1];
+}
+
+fn nextNonCommentToken(token_tags: []const std.zig.Token.Tag, start: usize) ?usize {
+    var index = start;
+    while (index < token_tags.len) : (index += 1) {
+        switch (token_tags[index]) {
+            .container_doc_comment, .doc_comment => continue,
+            else => return index,
+        }
+    }
+    return null;
+}
+
+fn prevNonCommentToken(token_tags: []const std.zig.Token.Tag, start: usize) ?usize {
+    if (start == 0) return null;
+    var index = start - 1;
+    while (true) {
+        switch (token_tags[index]) {
+            .container_doc_comment, .doc_comment => {},
+            else => return index,
+        }
+        if (index == 0) return null;
+        index -= 1;
+    }
+}
+
+fn identifierName(tree: *const std.zig.Ast, node: usize) ?[]const u8 {
+    const tags = tree.nodes.items(.tag);
+    if (node >= tags.len or tags[node] != .identifier) return null;
+    const main_tokens = tree.nodes.items(.main_token);
+    if (node >= main_tokens.len) return null;
+    return normalizeIdentifier(tree.tokenSlice(main_tokens[node]));
+}
+
+fn fieldAccessName(tree: *const std.zig.Ast, node: usize) ?[]const u8 {
+    const tags = tree.nodes.items(.tag);
+    if (node >= tags.len or tags[node] != .field_access) return null;
+    const datas = tree.nodes.items(.data);
+    return normalizeIdentifier(tree.tokenSlice(datas[node].node_and_token[1]));
+}
+
+fn isTypeLikeAlias(public_name: []const u8, referenced_name: []const u8) bool {
+    return isTypeLikeName(normalizeIdentifier(public_name)) and isTypeLikeName(normalizeIdentifier(referenced_name));
+}
+
+fn isTypeLikeName(name: []const u8) bool {
+    if (name.len == 0) return false;
+    return std.ascii.isUpper(name[0]);
+}
+
+fn pathsEquivalent(a: []const u8, b: []const u8) bool {
+    var a_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var b_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const normalized_a = normalizePath(&a_buf, a) catch return false;
+    const normalized_b = normalizePath(&b_buf, b) catch return false;
+    return std.mem.eql(u8, normalized_a, normalized_b);
+}
+
+fn normalizePath(buffer: []u8, path: []const u8) ![]const u8 {
+    var segments: [128][]const u8 = undefined;
+    var segment_count: usize = 0;
+
+    var rest = path;
+    while (rest.len > 0) {
+        const slash_index = std.mem.indexOfScalar(u8, rest, '/') orelse rest.len;
+        const segment = rest[0..slash_index];
+        if (segment.len != 0 and !std.mem.eql(u8, segment, ".")) {
+            if (std.mem.eql(u8, segment, "..") and segment_count > 0) {
+                segment_count -= 1;
+            } else {
+                if (segment_count >= segments.len) return error.PathTooManySegments;
+                segments[segment_count] = segment;
+                segment_count += 1;
+            }
+        }
+        if (slash_index == rest.len) break;
+        rest = rest[slash_index + 1 ..];
+    }
+
+    var len: usize = 0;
+    for (segments[0..segment_count]) |segment| {
+        if (len != 0) {
+            if (len >= buffer.len) return error.PathTooLong;
+            buffer[len] = '/';
+            len += 1;
+        }
+        if (len + segment.len > buffer.len) return error.PathTooLong;
+        @memcpy(buffer[len..][0..segment.len], segment);
+        len += segment.len;
+    }
+
+    return buffer[0..len];
 }
 
 fn normalizeIdentifier(ident: []const u8) []const u8 {

--- a/src/project_unused_decl.zig
+++ b/src/project_unused_decl.zig
@@ -1,0 +1,349 @@
+const std = @import("std");
+const Diagnostic = @import("diagnostic.zig").Diagnostic;
+const Source = @import("source.zig").Source;
+const suppression = @import("suppression.zig");
+
+const rule_id = "unused-decl";
+
+const DeclKind = enum {
+    function,
+    type_decl,
+    constant,
+    variable,
+    declaration,
+
+    fn description(self: DeclKind) []const u8 {
+        return switch (self) {
+            .function => "Function",
+            .type_decl => "Type",
+            .constant => "Constant",
+            .variable => "Variable",
+            .declaration => "Declaration",
+        };
+    }
+};
+
+const FileInfo = struct {
+    path: []const u8,
+    content: [:0]const u8,
+    tree: std.zig.Ast,
+
+    fn deinit(self: *FileInfo, allocator: std.mem.Allocator) void {
+        self.tree.deinit(allocator);
+        allocator.free(self.content.ptr[0 .. self.content.len + 1]);
+    }
+};
+
+const DeclInfo = struct {
+    file_index: usize,
+    name: []const u8,
+    normalized_name: []const u8,
+    byte_offset: usize,
+    kind: DeclKind,
+
+    fn deinit(self: *DeclInfo, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.normalized_name);
+    }
+};
+
+pub fn analyze(
+    allocator: std.mem.Allocator,
+    file_paths: []const []const u8,
+    diagnostics: *std.ArrayList(Diagnostic),
+) !void {
+    if (file_paths.len < 2) return;
+
+    var files: std.ArrayList(FileInfo) = .empty;
+    defer {
+        for (files.items) |*file| file.deinit(allocator);
+        files.deinit(allocator);
+    }
+
+    for (file_paths) |path| {
+        const file = try std.fs.cwd().openFile(path, .{});
+        defer file.close();
+
+        const max_size = 10 * 1024 * 1024;
+        // Sentinel needed for std.zig.Ast.parse; free accounts for sentinel byte below.
+        // zwanzig-disable-next-line: sentinel-alloc
+        const content = try file.readToEndAllocOptions(
+            allocator,
+            max_size,
+            null,
+            std.mem.Alignment.of(u8),
+            0,
+        );
+        errdefer allocator.free(content.ptr[0 .. content.len + 1]);
+
+        var tree = try std.zig.Ast.parse(allocator, content, .zig);
+        errdefer tree.deinit(allocator);
+
+        try files.append(allocator, .{
+            .path = path,
+            .content = content,
+            .tree = tree,
+        });
+    }
+
+    var decls: std.ArrayList(DeclInfo) = .empty;
+    defer {
+        for (decls.items) |*decl| decl.deinit(allocator);
+        decls.deinit(allocator);
+    }
+
+    for (files.items, 0..) |*file, file_index| {
+        try collectPublicRootDecls(allocator, &file.tree, file_index, &decls);
+    }
+
+    for (decls.items) |decl| {
+        if (isReferencedFromAnotherFile(files.items, decl)) continue;
+
+        var source = Source.init(allocator, files.items[decl.file_index].path, files.items[decl.file_index].content);
+        defer source.deinit();
+        const range = try source.byteRangeToSourceRange(decl.byte_offset, decl.byte_offset + decl.name.len);
+
+        var sup_map = try suppression.parseSuppressions(allocator, files.items[decl.file_index].content);
+        defer sup_map.deinit();
+        if (sup_map.isSuppressed(range.start.line, rule_id)) continue;
+
+        const message = try std.fmt.allocPrint(
+            allocator,
+            "{s} '{s}' is never used by another analyzed file",
+            .{ decl.kind.description(), decl.name },
+        );
+        defer allocator.free(message);
+
+        const diag = try Diagnostic.init(
+            allocator,
+            files.items[decl.file_index].path,
+            rule_id,
+            .warning,
+            message,
+            range,
+        );
+        try diagnostics.append(allocator, diag);
+    }
+}
+
+fn collectPublicRootDecls(
+    allocator: std.mem.Allocator,
+    tree: *const std.zig.Ast,
+    file_index: usize,
+    decls: *std.ArrayList(DeclInfo),
+) !void {
+    const tags = tree.nodes.items(.tag);
+    const token_starts = tree.tokens.items(.start);
+
+    for (tree.rootDecls()) |decl_idx| {
+        const idx = @intFromEnum(decl_idx);
+        const info = switch (tags[idx]) {
+            .simple_var_decl,
+            .aligned_var_decl,
+            .global_var_decl,
+            => try extractPublicVarDecl(allocator, tree, @intCast(idx), token_starts, file_index),
+            .fn_decl,
+            .fn_proto,
+            .fn_proto_simple,
+            .fn_proto_one,
+            .fn_proto_multi,
+            => try extractPublicFnDecl(allocator, tree, @intCast(idx), token_starts, file_index),
+            else => null,
+        };
+
+        if (info) |decl| {
+            if (isSpecialName(decl.name)) {
+                var mutable_decl = decl;
+                mutable_decl.deinit(allocator);
+                continue;
+            }
+            try decls.append(allocator, decl);
+        }
+    }
+}
+
+fn extractPublicVarDecl(
+    allocator: std.mem.Allocator,
+    tree: *const std.zig.Ast,
+    node_idx: u32,
+    token_starts: []const u32,
+    file_index: usize,
+) !?DeclInfo {
+    const full = tree.fullVarDecl(@enumFromInt(node_idx)) orelse return null;
+    if (!isPubToken(tree, full.visib_token)) return null;
+    if (full.extern_export_token != null) return null;
+
+    const token_tags = tree.tokens.items(.tag);
+    const name_token = full.ast.mut_token + 1;
+    if (name_token >= token_tags.len) return null;
+    if (token_tags[name_token] != .identifier) return null;
+
+    const name = tree.tokenSlice(name_token);
+    return makeDeclInfo(
+        allocator,
+        file_index,
+        name,
+        token_starts[name_token],
+        classifyVarDecl(tree, full),
+    );
+}
+
+fn extractPublicFnDecl(
+    allocator: std.mem.Allocator,
+    tree: *const std.zig.Ast,
+    node_idx: u32,
+    token_starts: []const u32,
+    file_index: usize,
+) !?DeclInfo {
+    const tags = tree.nodes.items(.tag);
+    const tag = tags[node_idx];
+    var buffer: [1]std.zig.Ast.Node.Index = undefined;
+
+    return switch (tag) {
+        .fn_decl => blk: {
+            const data = tree.nodes.items(.data)[node_idx];
+            const proto_node = @intFromEnum(data.node_and_node[0]);
+            break :blk extractPublicFnDecl(allocator, tree, proto_node, token_starts, file_index);
+        },
+        .fn_proto => extractPublicFnProto(
+            allocator,
+            tree,
+            tree.fnProto(@enumFromInt(node_idx)),
+            token_starts,
+            file_index,
+        ),
+        .fn_proto_simple => extractPublicFnProto(
+            allocator,
+            tree,
+            tree.fnProtoSimple(&buffer, @enumFromInt(node_idx)),
+            token_starts,
+            file_index,
+        ),
+        .fn_proto_one => extractPublicFnProto(
+            allocator,
+            tree,
+            tree.fnProtoOne(&buffer, @enumFromInt(node_idx)),
+            token_starts,
+            file_index,
+        ),
+        .fn_proto_multi => extractPublicFnProto(
+            allocator,
+            tree,
+            tree.fnProtoMulti(@enumFromInt(node_idx)),
+            token_starts,
+            file_index,
+        ),
+        else => null,
+    };
+}
+
+fn extractPublicFnProto(
+    allocator: std.mem.Allocator,
+    tree: *const std.zig.Ast,
+    proto: std.zig.Ast.full.FnProto,
+    token_starts: []const u32,
+    file_index: usize,
+) !?DeclInfo {
+    if (!isPubToken(tree, proto.visib_token)) return null;
+    if (proto.extern_export_inline_token) |tok| {
+        const tag = tree.tokenTag(tok);
+        if (tag == .keyword_extern or tag == .keyword_export) return null;
+    }
+
+    const name_token = proto.name_token orelse return null;
+    if (tree.tokenTag(name_token) != .identifier) return null;
+
+    return makeDeclInfo(
+        allocator,
+        file_index,
+        tree.tokenSlice(name_token),
+        token_starts[name_token],
+        .function,
+    );
+}
+
+fn makeDeclInfo(
+    allocator: std.mem.Allocator,
+    file_index: usize,
+    name: []const u8,
+    byte_offset: usize,
+    kind: DeclKind,
+) !DeclInfo {
+    const name_copy = try allocator.dupe(u8, name);
+    errdefer allocator.free(name_copy);
+    const normalized_copy = try allocator.dupe(u8, normalizeIdentifier(name));
+    return .{
+        .file_index = file_index,
+        .name = name_copy,
+        .normalized_name = normalized_copy,
+        .byte_offset = byte_offset,
+        .kind = kind,
+    };
+}
+
+fn isPubToken(tree: *const std.zig.Ast, token: ?std.zig.Ast.TokenIndex) bool {
+    const tok = token orelse return false;
+    return tree.tokenTag(tok) == .keyword_pub;
+}
+
+fn classifyVarDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) DeclKind {
+    if (full.ast.init_node.unwrap()) |init_node| {
+        if (isContainerTag(tree.nodes.items(.tag)[@intFromEnum(init_node)])) return .type_decl;
+    }
+    const mut_tag = tree.tokenTag(full.ast.mut_token);
+    if (mut_tag == .keyword_const) return .constant;
+    if (mut_tag == .keyword_var) return .variable;
+    return .declaration;
+}
+
+fn isReferencedFromAnotherFile(files: []const FileInfo, decl: DeclInfo) bool {
+    for (files, 0..) |*file, file_index| {
+        if (file_index == decl.file_index) continue;
+        if (fileReferencesName(&file.tree, decl.normalized_name)) return true;
+    }
+    return false;
+}
+
+fn fileReferencesName(tree: *const std.zig.Ast, normalized_name: []const u8) bool {
+    const token_tags = tree.tokens.items(.tag);
+    for (token_tags, 0..) |tag, token_index| {
+        if (tag != .identifier) continue;
+        const slice = normalizeIdentifier(tree.tokenSlice(@intCast(token_index)));
+        if (std.mem.eql(u8, slice, normalized_name)) return true;
+    }
+    return false;
+}
+
+fn normalizeIdentifier(ident: []const u8) []const u8 {
+    if (ident.len >= 3 and std.mem.startsWith(u8, ident, "@\"") and ident[ident.len - 1] == '"') {
+        return ident[2 .. ident.len - 1];
+    }
+    return ident;
+}
+
+fn isSpecialName(name: []const u8) bool {
+    if (name.len > 0 and name[0] == '_') return true;
+    if (std.mem.eql(u8, name, "main")) return true;
+    if (std.mem.eql(u8, name, "panic")) return true;
+    if (std.mem.eql(u8, name, "std_options")) return true;
+    return false;
+}
+
+fn isContainerTag(tag: std.zig.Ast.Node.Tag) bool {
+    return switch (tag) {
+        .container_decl,
+        .container_decl_trailing,
+        .container_decl_two,
+        .container_decl_two_trailing,
+        .container_decl_arg,
+        .container_decl_arg_trailing,
+        .tagged_union,
+        .tagged_union_trailing,
+        .tagged_union_enum_tag,
+        .tagged_union_enum_tag_trailing,
+        .tagged_union_two,
+        .tagged_union_two_trailing,
+        => true,
+        else => false,
+    };
+}

--- a/src/suppression.zig
+++ b/src/suppression.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub const SuppressionError = error{
+const SuppressionError = error{
     OutOfMemory,
 };
 

--- a/test/fixture_tests.zig
+++ b/test/fixture_tests.zig
@@ -112,6 +112,143 @@ test "project-wide unused declarations ignore public aliases" {
     try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[1].message, "unusedFunction") != null);
 }
 
+test "project-wide unused declarations follow public API surfaces" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/api_surface_main.zig",
+        "test/fixtures/project_unused_decl/api_surface.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 3), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "HelperForUnusedApi") != null);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[1].message, "unusedApi") != null);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[2].message, "unusedFunction") != null);
+}
+
+test "project-wide unused declarations ignore package API entrypoints" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/src/lib.zig",
+        "test/fixtures/project_unused_decl/src/public_api.zig",
+        "test/fixtures/project_unused_decl/src/private_api.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "hiddenUnused") != null);
+}
+
+test "project-wide unused declarations normalize quoted identifiers" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/quoted_main.zig",
+        "test/fixtures/project_unused_decl/quoted_api.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "unused-name") != null);
+}
+
+test "project-wide unused declarations ignore externally visible and special public declarations" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/ignored_publics.zig",
+        "test/fixtures/project_unused_decl/ignored_publics_main.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 0), analyzer.diagnostics.items.len);
+}
+
+test "project-wide unused declarations follow nested public API surfaces" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/nested_surface_main.zig",
+        "test/fixtures/project_unused_decl/nested_surface.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "UnusedNestedHelper") != null);
+}
+
+test "project-wide unused declarations follow tagged union public API surfaces" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/union_surface_main.zig",
+        "test/fixtures/project_unused_decl/union_surface.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "UnusedUnionHelper") != null);
+}
+
+test "project-wide unused declarations do not treat function bodies as public API surface" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/body_surface_main.zig",
+        "test/fixtures/project_unused_decl/body_surface.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "unusedPublicHelper") != null);
+}
+
+test "project-wide unused declarations honor suppressions" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/suppressed_api.zig",
+        "test/fixtures/project_unused_decl/suppressed_main.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 0), analyzer.diagnostics.items.len);
+}
+
 test "identifier_style fixtures" {
     try runFixturesInDir(std.testing.allocator, &IdentifierStyleRule.rule, "test/fixtures/identifier_style");
 }

--- a/test/fixture_tests.zig
+++ b/test/fixture_tests.zig
@@ -149,6 +149,38 @@ test "project-wide unused declarations ignore package API entrypoints" {
     try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "hiddenUnused") != null);
 }
 
+test "project-wide unused declarations ignore package usingnamespace entrypoints" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/usingnamespace_pkg/src/lib.zig",
+        "test/fixtures/project_unused_decl/usingnamespace_pkg/src/public_api.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 0), analyzer.diagnostics.items.len);
+}
+
+test "project-wide unused declarations ignore duplicate-only inputs" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/duplicate_a.zig",
+        "test/fixtures/project_unused_decl/duplicate_a.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 0), analyzer.diagnostics.items.len);
+}
+
 test "project-wide unused declarations normalize quoted identifiers" {
     var analyzer = src.Analyzer.init(std.testing.allocator);
     defer analyzer.deinit();
@@ -180,6 +212,25 @@ test "project-wide unused declarations ignore externally visible and special pub
     try analyzer.analyzeProjectUnusedDecls(&files);
 
     try std.testing.expectEqual(@as(usize, 0), analyzer.diagnostics.items.len);
+}
+
+test "project-wide unused declarations ignore unrelated field accesses" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/unrelated_field_main.zig",
+        "test/fixtures/project_unused_decl/unrelated_field_api.zig",
+        "test/fixtures/project_unused_decl/unrelated_field_other.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expectEqualStrings("test/fixtures/project_unused_decl/unrelated_field_api.zig", analyzer.diagnostics.items[0].file_path);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "init") != null);
 }
 
 test "project-wide unused declarations follow nested public API surfaces" {
@@ -231,6 +282,58 @@ test "project-wide unused declarations do not treat function bodies as public AP
 
     try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
     try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "unusedPublicHelper") != null);
+}
+
+test "project-wide unused declarations report public constants copied from values" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/value_alias.zig",
+        "test/fixtures/project_unused_decl/value_alias_main.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 2), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "DefaultTimeoutMs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[1].message, "DefaultLimit") != null);
+}
+
+test "project-wide unused declarations follow usingnamespace bare references" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/usingnamespace_main.zig",
+        "test/fixtures/project_unused_decl/usingnamespace_api.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "unused") != null);
+}
+
+test "project-wide unused declarations classify error sets as types" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/error_set_api.zig",
+        "test/fixtures/project_unused_decl/error_set_main.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "Type 'ApiError'") != null);
 }
 
 test "project-wide unused declarations honor suppressions" {

--- a/test/fixture_tests.zig
+++ b/test/fixture_tests.zig
@@ -75,6 +75,25 @@ test "project-wide unused declarations" {
     try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "unusedByProject") != null);
 }
 
+test "project-wide unused declarations ignore duplicate names and paths" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{ "unused-decl" };
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/duplicate_a.zig",
+        "test/fixtures/project_unused_decl/duplicate_a.zig",
+        "test/fixtures/project_unused_decl/duplicate_b.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 2), analyzer.diagnostics.items.len);
+    try std.testing.expectEqualStrings("test/fixtures/project_unused_decl/duplicate_a.zig", analyzer.diagnostics.items[0].file_path);
+    try std.testing.expectEqualStrings("test/fixtures/project_unused_decl/duplicate_b.zig", analyzer.diagnostics.items[1].file_path);
+}
+
 test "identifier_style fixtures" {
     try runFixturesInDir(std.testing.allocator, &IdentifierStyleRule.rule, "test/fixtures/identifier_style");
 }

--- a/test/fixture_tests.zig
+++ b/test/fixture_tests.zig
@@ -61,7 +61,7 @@ test "project-wide unused declarations" {
     var analyzer = src.Analyzer.init(std.testing.allocator);
     defer analyzer.deinit();
 
-    const allowlist = [_][]const u8{ "unused-decl" };
+    const allowlist = [_][]const u8{"unused-decl"};
     analyzer.setRuleFilter(.{ .allowlist = &allowlist });
 
     const files = [_][]const u8{
@@ -79,7 +79,7 @@ test "project-wide unused declarations ignore duplicate names and paths" {
     var analyzer = src.Analyzer.init(std.testing.allocator);
     defer analyzer.deinit();
 
-    const allowlist = [_][]const u8{ "unused-decl" };
+    const allowlist = [_][]const u8{"unused-decl"};
     analyzer.setRuleFilter(.{ .allowlist = &allowlist });
 
     const files = [_][]const u8{
@@ -92,6 +92,24 @@ test "project-wide unused declarations ignore duplicate names and paths" {
     try std.testing.expectEqual(@as(usize, 2), analyzer.diagnostics.items.len);
     try std.testing.expectEqualStrings("test/fixtures/project_unused_decl/duplicate_a.zig", analyzer.diagnostics.items[0].file_path);
     try std.testing.expectEqualStrings("test/fixtures/project_unused_decl/duplicate_b.zig", analyzer.diagnostics.items[1].file_path);
+}
+
+test "project-wide unused declarations ignore public aliases" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/alias.zig",
+        "test/fixtures/project_unused_decl/alias_inner.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 2), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "RegularType") != null);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[1].message, "unusedFunction") != null);
 }
 
 test "identifier_style fixtures" {

--- a/test/fixture_tests.zig
+++ b/test/fixture_tests.zig
@@ -125,10 +125,9 @@ test "project-wide unused declarations follow public API surfaces" {
     };
     try analyzer.analyzeProjectUnusedDecls(&files);
 
-    try std.testing.expectEqual(@as(usize, 3), analyzer.diagnostics.items.len);
-    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "HelperForUnusedApi") != null);
-    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[1].message, "unusedApi") != null);
-    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[2].message, "unusedFunction") != null);
+    try std.testing.expectEqual(@as(usize, 2), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "unusedApi") != null);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[1].message, "unusedFunction") != null);
 }
 
 test "project-wide unused declarations ignore package API entrypoints" {
@@ -267,7 +266,7 @@ test "project-wide unused declarations follow tagged union public API surfaces" 
     try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "UnusedUnionHelper") != null);
 }
 
-test "project-wide unused declarations do not treat function bodies as public API surface" {
+test "project-wide unused declarations count same-file function body references" {
     var analyzer = src.Analyzer.init(std.testing.allocator);
     defer analyzer.deinit();
 
@@ -280,8 +279,7 @@ test "project-wide unused declarations do not treat function bodies as public AP
     };
     try analyzer.analyzeProjectUnusedDecls(&files);
 
-    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
-    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "unusedPublicHelper") != null);
+    try std.testing.expectEqual(@as(usize, 0), analyzer.diagnostics.items.len);
 }
 
 test "project-wide unused declarations report public constants copied from values" {

--- a/test/fixture_tests.zig
+++ b/test/fixture_tests.zig
@@ -57,6 +57,24 @@ test "shadowed_variable fixtures" {
     try runFixturesInDir(std.testing.allocator, &ShadowedVariableRule.rule, "test/fixtures/shadowed_variable");
 }
 
+test "project-wide unused declarations" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{ "unused-decl" };
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/main.zig",
+        "test/fixtures/project_unused_decl/api.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expectEqualStrings("unused-decl", analyzer.diagnostics.items[0].rule_id);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "unusedByProject") != null);
+}
+
 test "identifier_style fixtures" {
     try runFixturesInDir(std.testing.allocator, &IdentifierStyleRule.rule, "test/fixtures/identifier_style");
 }

--- a/test/fixture_tests.zig
+++ b/test/fixture_tests.zig
@@ -138,6 +138,7 @@ test "project-wide unused declarations ignore package API entrypoints" {
     analyzer.setRuleFilter(.{ .allowlist = &allowlist });
 
     const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/build.zig",
         "test/fixtures/project_unused_decl/src/lib.zig",
         "test/fixtures/project_unused_decl/src/public_api.zig",
         "test/fixtures/project_unused_decl/src/private_api.zig",
@@ -156,12 +157,33 @@ test "project-wide unused declarations ignore package usingnamespace entrypoints
     analyzer.setRuleFilter(.{ .allowlist = &allowlist });
 
     const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/usingnamespace_pkg/build.zig",
         "test/fixtures/project_unused_decl/usingnamespace_pkg/src/lib.zig",
         "test/fixtures/project_unused_decl/usingnamespace_pkg/src/public_api.zig",
     };
     try analyzer.analyzeProjectUnusedDecls(&files);
 
     try std.testing.expectEqual(@as(usize, 0), analyzer.diagnostics.items.len);
+}
+
+test "project-wide unused declarations use build root source file" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/custom_root_pkg/build.zig",
+        "test/fixtures/project_unused_decl/custom_root_pkg/custom_root.zig",
+        "test/fixtures/project_unused_decl/custom_root_pkg/custom_public_api.zig",
+        "test/fixtures/project_unused_decl/custom_root_pkg/custom_private.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expectEqualStrings("test/fixtures/project_unused_decl/custom_root_pkg/custom_private.zig", analyzer.diagnostics.items[0].file_path);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "hiddenUnused") != null);
 }
 
 test "project-wide unused declarations ignore duplicate-only inputs" {
@@ -178,6 +200,40 @@ test "project-wide unused declarations ignore duplicate-only inputs" {
     try analyzer.analyzeProjectUnusedDecls(&files);
 
     try std.testing.expectEqual(@as(usize, 0), analyzer.diagnostics.items.len);
+}
+
+test "project-wide unused declarations follow typed receiver calls" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/typed_receiver_main.zig",
+        "test/fixtures/project_unused_decl/typed_receiver_api.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "unused") != null);
+}
+
+test "project-wide unused declarations follow result-location method calls" {
+    var analyzer = src.Analyzer.init(std.testing.allocator);
+    defer analyzer.deinit();
+
+    const allowlist = [_][]const u8{"unused-decl"};
+    analyzer.setRuleFilter(.{ .allowlist = &allowlist });
+
+    const files = [_][]const u8{
+        "test/fixtures/project_unused_decl/result_location_main.zig",
+        "test/fixtures/project_unused_decl/result_location_api.zig",
+    };
+    try analyzer.analyzeProjectUnusedDecls(&files);
+
+    try std.testing.expectEqual(@as(usize, 1), analyzer.diagnostics.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, analyzer.diagnostics.items[0].message, "unused") != null);
 }
 
 test "project-wide unused declarations normalize quoted identifiers" {

--- a/test/fixtures/project_unused_decl/alias.zig
+++ b/test/fixtures/project_unused_decl/alias.zig
@@ -1,0 +1,8 @@
+const inner = @import("alias_inner.zig");
+
+pub const ImportedModule = @import("alias_inner.zig");
+pub const ExportedType = inner.Exported;
+pub const SameModuleAlias = ExportedType;
+pub const RegularType = struct {};
+
+pub fn unusedFunction() void {}

--- a/test/fixtures/project_unused_decl/alias_inner.zig
+++ b/test/fixtures/project_unused_decl/alias_inner.zig
@@ -1,0 +1,1 @@
+pub const Exported = struct {};

--- a/test/fixtures/project_unused_decl/api.zig
+++ b/test/fixtures/project_unused_decl/api.zig
@@ -1,0 +1,3 @@
+pub fn usedByMain() void {}
+
+pub fn unusedByProject() void {}

--- a/test/fixtures/project_unused_decl/api_surface.zig
+++ b/test/fixtures/project_unused_decl/api_surface.zig
@@ -1,0 +1,34 @@
+pub const Exposed = struct {
+    font: FontConfig = .{},
+    load_error: ?LoadError = null,
+};
+
+pub const FontConfig = struct {
+    family: []const u8 = "mono",
+};
+
+pub const LoadError = error{
+    Invalid,
+};
+
+pub const HelperForUnusedApi = struct {};
+
+pub const StreamType = TypeFactory(Handler);
+
+pub const Handler = struct {};
+
+pub fn makeExposed() Exposed {
+    return .{};
+}
+
+pub fn unusedApi() HelperForUnusedApi {
+    return .{};
+}
+
+pub fn unusedFunction() void {}
+
+fn TypeFactory(comptime T: type) type {
+    return struct {
+        value: T,
+    };
+}

--- a/test/fixtures/project_unused_decl/api_surface_main.zig
+++ b/test/fixtures/project_unused_decl/api_surface_main.zig
@@ -1,0 +1,6 @@
+const api_surface = @import("api_surface.zig");
+
+pub fn main() void {
+    _ = api_surface.makeExposed();
+    _ = api_surface.StreamType;
+}

--- a/test/fixtures/project_unused_decl/body_surface.zig
+++ b/test/fixtures/project_unused_decl/body_surface.zig
@@ -1,0 +1,5 @@
+pub fn usedApi() void {
+    unusedPublicHelper();
+}
+
+pub fn unusedPublicHelper() void {}

--- a/test/fixtures/project_unused_decl/body_surface_main.zig
+++ b/test/fixtures/project_unused_decl/body_surface_main.zig
@@ -1,0 +1,5 @@
+const api = @import("body_surface.zig");
+
+pub fn main() void {
+    api.usedApi();
+}

--- a/test/fixtures/project_unused_decl/build.zig
+++ b/test/fixtures/project_unused_decl/build.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    _ = b.addModule("project-unused-decl-fixture", .{
+        .root_source_file = b.path("src/lib.zig"),
+    });
+}

--- a/test/fixtures/project_unused_decl/custom_root_pkg/build.zig
+++ b/test/fixtures/project_unused_decl/custom_root_pkg/build.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    _ = b.addModule("custom-root-fixture", .{
+        .root_source_file = b.path("custom_root.zig"),
+    });
+}

--- a/test/fixtures/project_unused_decl/custom_root_pkg/custom_private.zig
+++ b/test/fixtures/project_unused_decl/custom_root_pkg/custom_private.zig
@@ -1,0 +1,1 @@
+pub fn hiddenUnused() void {}

--- a/test/fixtures/project_unused_decl/custom_root_pkg/custom_public_api.zig
+++ b/test/fixtures/project_unused_decl/custom_root_pkg/custom_public_api.zig
@@ -1,0 +1,1 @@
+pub fn publicExport() void {}

--- a/test/fixtures/project_unused_decl/custom_root_pkg/custom_root.zig
+++ b/test/fixtures/project_unused_decl/custom_root_pkg/custom_root.zig
@@ -1,0 +1,3 @@
+pub const PublicApi = @import("custom_public_api.zig");
+
+pub fn rootExport() void {}

--- a/test/fixtures/project_unused_decl/duplicate_a.zig
+++ b/test/fixtures/project_unused_decl/duplicate_a.zig
@@ -1,0 +1,1 @@
+pub fn init() void {}

--- a/test/fixtures/project_unused_decl/duplicate_b.zig
+++ b/test/fixtures/project_unused_decl/duplicate_b.zig
@@ -1,0 +1,1 @@
+pub fn init() void {}

--- a/test/fixtures/project_unused_decl/error_set_api.zig
+++ b/test/fixtures/project_unused_decl/error_set_api.zig
@@ -1,0 +1,3 @@
+pub const ApiError = error{
+    Failed,
+};

--- a/test/fixtures/project_unused_decl/error_set_main.zig
+++ b/test/fixtures/project_unused_decl/error_set_main.zig
@@ -1,0 +1,1 @@
+pub fn main() void {}

--- a/test/fixtures/project_unused_decl/ignored_publics.zig
+++ b/test/fixtures/project_unused_decl/ignored_publics.zig
@@ -1,0 +1,16 @@
+pub extern fn externalFunction() void;
+
+pub export fn exportedFunction() void {}
+
+pub fn main() void {}
+
+pub fn panic(message: []const u8, stack_trace: ?*anyopaque, ret_addr: usize) noreturn {
+    _ = message;
+    _ = stack_trace;
+    _ = ret_addr;
+    while (true) {}
+}
+
+pub const _explicitly_ignored = 1;
+
+pub const std_options = struct {};

--- a/test/fixtures/project_unused_decl/ignored_publics_main.zig
+++ b/test/fixtures/project_unused_decl/ignored_publics_main.zig
@@ -1,0 +1,1 @@
+pub fn main() void {}

--- a/test/fixtures/project_unused_decl/main.zig
+++ b/test/fixtures/project_unused_decl/main.zig
@@ -1,0 +1,5 @@
+const api = @import("api.zig");
+
+pub fn main() void {
+    api.usedByMain();
+}

--- a/test/fixtures/project_unused_decl/nested_surface.zig
+++ b/test/fixtures/project_unused_decl/nested_surface.zig
@@ -1,0 +1,9 @@
+pub const Options = struct {
+    pub fn makeHandler() Handler {
+        return .{};
+    }
+};
+
+pub const Handler = struct {};
+
+pub const UnusedNestedHelper = struct {};

--- a/test/fixtures/project_unused_decl/nested_surface_main.zig
+++ b/test/fixtures/project_unused_decl/nested_surface_main.zig
@@ -1,0 +1,5 @@
+const api = @import("nested_surface.zig");
+
+pub fn main() void {
+    _ = api.Options;
+}

--- a/test/fixtures/project_unused_decl/quoted_api.zig
+++ b/test/fixtures/project_unused_decl/quoted_api.zig
@@ -1,0 +1,3 @@
+pub fn @"used-name"() void {}
+
+pub fn @"unused-name"() void {}

--- a/test/fixtures/project_unused_decl/quoted_main.zig
+++ b/test/fixtures/project_unused_decl/quoted_main.zig
@@ -1,0 +1,5 @@
+const api = @import("quoted_api.zig");
+
+pub fn main() void {
+    api.@"used-name"();
+}

--- a/test/fixtures/project_unused_decl/result_location_api.zig
+++ b/test/fixtures/project_unused_decl/result_location_api.zig
@@ -1,0 +1,11 @@
+const Api = @This();
+
+pub fn create() !*Api {
+    unreachable;
+}
+
+pub fn init() Api {
+    return .{};
+}
+
+pub fn unused() void {}

--- a/test/fixtures/project_unused_decl/result_location_main.zig
+++ b/test/fixtures/project_unused_decl/result_location_main.zig
@@ -1,0 +1,9 @@
+const Api = @import("result_location_api.zig");
+
+pub fn main() !void {
+    const pointer: *Api = try .create();
+    const value: Api = .init();
+
+    _ = pointer;
+    _ = value;
+}

--- a/test/fixtures/project_unused_decl/src/lib.zig
+++ b/test/fixtures/project_unused_decl/src/lib.zig
@@ -1,3 +1,3 @@
-pub const PublicApi = @import("public_api.zig");
+pub const PublicApi = @import("./public_api.zig");
 
 pub fn rootEntry() void {}

--- a/test/fixtures/project_unused_decl/src/lib.zig
+++ b/test/fixtures/project_unused_decl/src/lib.zig
@@ -1,0 +1,3 @@
+pub const PublicApi = @import("public_api.zig");
+
+pub fn rootEntry() void {}

--- a/test/fixtures/project_unused_decl/src/private_api.zig
+++ b/test/fixtures/project_unused_decl/src/private_api.zig
@@ -1,0 +1,1 @@
+pub fn hiddenUnused() void {}

--- a/test/fixtures/project_unused_decl/src/public_api.zig
+++ b/test/fixtures/project_unused_decl/src/public_api.zig
@@ -1,0 +1,3 @@
+pub const FacadeType = struct {};
+
+pub fn facadeFunction() void {}

--- a/test/fixtures/project_unused_decl/suppressed_api.zig
+++ b/test/fixtures/project_unused_decl/suppressed_api.zig
@@ -1,0 +1,2 @@
+// zwanzig-disable-next-line: unused-decl
+pub fn intentionallyUnused() void {}

--- a/test/fixtures/project_unused_decl/suppressed_main.zig
+++ b/test/fixtures/project_unused_decl/suppressed_main.zig
@@ -1,0 +1,1 @@
+pub fn main() void {}

--- a/test/fixtures/project_unused_decl/typed_receiver_api.zig
+++ b/test/fixtures/project_unused_decl/typed_receiver_api.zig
@@ -1,0 +1,25 @@
+const Api = @This();
+
+pub fn init() Api {
+    return .{};
+}
+
+pub fn deinit(self: *Api) void {
+    _ = self;
+}
+
+pub fn run(self: *Api) void {
+    _ = self;
+}
+
+pub fn fieldRun(self: *Api) void {
+    _ = self;
+}
+
+pub fn pointerRun(self: *Api) void {
+    _ = self;
+}
+
+pub fn unused(self: *Api) void {
+    _ = self;
+}

--- a/test/fixtures/project_unused_decl/typed_receiver_main.zig
+++ b/test/fixtures/project_unused_decl/typed_receiver_main.zig
@@ -1,0 +1,24 @@
+const Api = @import("typed_receiver_api.zig");
+
+const Wrapper = struct {
+    api: Api,
+
+    fn call(self: *Wrapper) void {
+        self.api.fieldRun();
+    }
+};
+
+pub fn main() void {
+    var value = Api.init();
+    defer value.deinit();
+    value.run();
+
+    var wrapper = Wrapper{ .api = value };
+    wrapper.call();
+
+    callThroughPointer(&value);
+}
+
+fn callThroughPointer(api: *Api) void {
+    api.pointerRun();
+}

--- a/test/fixtures/project_unused_decl/union_surface.zig
+++ b/test/fixtures/project_unused_decl/union_surface.zig
@@ -1,0 +1,11 @@
+pub const Event = union(EventTag) {
+    click: Click,
+};
+
+pub const EventTag = enum {
+    click,
+};
+
+pub const Click = struct {};
+
+pub const UnusedUnionHelper = struct {};

--- a/test/fixtures/project_unused_decl/union_surface_main.zig
+++ b/test/fixtures/project_unused_decl/union_surface_main.zig
@@ -1,0 +1,5 @@
+const api = @import("union_surface.zig");
+
+pub fn main() void {
+    _ = api.Event;
+}

--- a/test/fixtures/project_unused_decl/unrelated_field_api.zig
+++ b/test/fixtures/project_unused_decl/unrelated_field_api.zig
@@ -1,0 +1,1 @@
+pub fn init() void {}

--- a/test/fixtures/project_unused_decl/unrelated_field_main.zig
+++ b/test/fixtures/project_unused_decl/unrelated_field_main.zig
@@ -1,0 +1,5 @@
+const other = @import("unrelated_field_other.zig");
+
+pub fn main() void {
+    other.init();
+}

--- a/test/fixtures/project_unused_decl/unrelated_field_other.zig
+++ b/test/fixtures/project_unused_decl/unrelated_field_other.zig
@@ -1,0 +1,1 @@
+pub fn init() void {}

--- a/test/fixtures/project_unused_decl/usingnamespace_api.zig
+++ b/test/fixtures/project_unused_decl/usingnamespace_api.zig
@@ -1,0 +1,3 @@
+pub fn exposed() void {}
+
+pub fn unused() void {}

--- a/test/fixtures/project_unused_decl/usingnamespace_main.zig
+++ b/test/fixtures/project_unused_decl/usingnamespace_main.zig
@@ -1,0 +1,5 @@
+usingnamespace @import("usingnamespace_api.zig");
+
+pub fn main() void {
+    exposed();
+}

--- a/test/fixtures/project_unused_decl/usingnamespace_pkg/build.zig
+++ b/test/fixtures/project_unused_decl/usingnamespace_pkg/build.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    _ = b.addModule("usingnamespace-fixture", .{
+        .root_source_file = b.path("src/lib.zig"),
+    });
+}

--- a/test/fixtures/project_unused_decl/usingnamespace_pkg/src/lib.zig
+++ b/test/fixtures/project_unused_decl/usingnamespace_pkg/src/lib.zig
@@ -1,0 +1,1 @@
+pub usingnamespace @import("./public_api.zig");

--- a/test/fixtures/project_unused_decl/usingnamespace_pkg/src/public_api.zig
+++ b/test/fixtures/project_unused_decl/usingnamespace_pkg/src/public_api.zig
@@ -1,0 +1,1 @@
+pub fn facadeFunction() void {}

--- a/test/fixtures/project_unused_decl/value_alias.zig
+++ b/test/fixtures/project_unused_decl/value_alias.zig
@@ -1,0 +1,11 @@
+const defaults = struct {
+    const timeout_ms = 1000;
+};
+
+const internal_limit = 10;
+
+pub const DefaultTimeoutMs = defaults.timeout_ms;
+
+pub const DefaultLimit = internal_limit;
+
+pub const ExportedType = defaults.ExportedType;

--- a/test/fixtures/project_unused_decl/value_alias_main.zig
+++ b/test/fixtures/project_unused_decl/value_alias_main.zig
@@ -1,0 +1,1 @@
+pub fn main() void {}


### PR DESCRIPTION
### Motivation

- Extend `unused-decl` from file-local checks to project-sized runs.
- Keep the project pass enabled by default when multiple files are analyzed, but make it precise enough for normal Zig packages.
- Avoid noisy reports from public facades, package entrypoints, and common file-struct method patterns.

### Description

- Adds a project-wide `unused-decl` pass that collects public top-level declarations and reports the ones that are not referenced by another analyzed file.
- Discovers package API roots from `root_source_file` entries in analyzed `build.zig` files, or from the workspace `build.zig` when analyzing a subdirectory.
- Ignores `build.zig`'s `pub fn build` entrypoint and alias-style public re-exports.
- Tracks import-aware cross-file references, `usingnamespace` imports, quoted identifiers, suppressions, and public API surface propagation through signatures, fields, and initializers.
- Uses lightweight type information for file-struct method calls, including typed receivers and result-location calls such as `const server: *Server = try .create(...)`.
- Adds fixture coverage for package roots, custom roots, public facades, `usingnamespace`, typed receivers, result-location calls, duplicate inputs, suppressions, and unrelated field accesses.
- Updates the rule documentation and changelog.

### Testing

- `just build`
- `just test`
- `just lint`
- `git diff --check`

I also spot-checked the project pass on cloned Zig codebases:

- `known-folders`: 0 project-wide warnings
- `zig-clap`: 0 project-wide warnings
- `libxev/src`: 23 project-wide warnings
- `zls/src`: 40 project-wide warnings; the earlier `Server.create` false positive is gone after result-location method handling

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1adc4687c48332963b9a7b71e123b8)
