### PR TITLE
Share project-aware call resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Shared project-aware import and call resolution across resource, stack-escape, sentinel allocation, and cleanup lifecycle checks, improving precision for identifier calls, typed receivers, FQNs, field-chain receivers, and result-location contexts (#92).
+
 ## [0.13.1] - 2026-06-01
 
 ### Added

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -274,6 +274,8 @@ Detected functions:
 - `allocWithOptions` with non-null sentinel parameter
 - `readToEndAllocOptions` with non-null sentinel parameter
 
+The rule uses shared result-location resolution for casts, variable declarations, assignments, and returns, so preserving `[:sentinel]T` through common factory and wrapper patterns suppresses the diagnostic.
+
 ### return-local-ptr
 
 Detects functions that return slices or pointers derived from local stack buffers. This catches use-after-return bugs where the returned data points to memory that becomes invalid when the function returns. The rule only reports when the function’s return type is a pointer/slice (including optional or error-union wrappers).
@@ -319,6 +321,8 @@ The hint does not trigger when:
 - The reinitialization is infallible (`x = make()`), since no error unwind can occur.
 - The receiver is assigned a non-`try` value before the `try` assignment, resetting it to a valid state.
 - The active deferred cleanup uses a different method than the direct call (`defer x.close()` with `x.deinit()` does not match).
+
+Receiver matching handles simple variables and field chains such as `holder.value.deinit()`, so lifecycle checks apply to cleanup methods on nested resources as well as local variables.
 
 **Bad (warning):**
 ```zig
@@ -657,7 +661,7 @@ Detects allocator/resource misuse: double-free, free-without-alloc, close-withou
 
 Resources stored in aggregates are treated as escaping with the aggregate.
 
-**Resource modeling:** Built-in allocator detection includes `alloc`/`free`, `dupe`, and `create`/`destroy`. Configurable `resource_models` can add project-specific APIs. `kind: "free_owned"` models APIs like `deinit` that free resources owned by a value without freeing the value itself.
+**Resource modeling:** Built-in allocator detection includes `alloc`/`free`, `dupe`, and `create`/`destroy`. Configurable `resource_models` can add project-specific APIs. Model matching uses shared call resolution for identifier calls, receiver methods, receiver types, and FQNs. `kind: "free_owned"` models APIs like `deinit` that free resources owned by a value without freeing the value itself.
 
 **Defer-frees-escapee detection:** When a value with a pending `defer <allocator>.free(x)` is passed into `append`/`appendSlice`/`appendAssumeCapacity`/`appendSliceAssumeCapacity`/`insert`/`insertSlice` on a container whose declaration outlives the defer's lexical scope, the engine reports a future use-after-free. "Outlives" covers function parameters, top-level decls, `self.field` chains, and any local container declared above the defer's block. The check applies uniformly to defers in any block — `if`, `while`, `for`, `switch` arms, plain `{ ... }`, and the function body itself — because the safety question is always the same: does the container survive past the moment the defer fires? Same-block local containers are not flagged: defers fire in reverse declaration order, so the container is destroyed before the resource. A direct slice argument to `appendSlice`/`appendSliceAssumeCapacity`/`insertSlice` (e.g. `try out.appendSlice(allocator, tmp)` or `tmp[start..end]`) is treated as the byte-copy idiom and not flagged; only nested references (e.g. `&.{tmp}`) trigger the diagnostic for those methods. `errdefer` is not flagged because the canonical `errdefer free(x); try list.append(x)` ownership-transfer idiom is correct on the success path. The `put`/`putAssumeCapacity` family is not flagged because many non-container APIs (caches, writers, IO sinks) share the same names but consume their input during the call; a future type-aware extension can lift these restrictions.
 
@@ -736,6 +740,8 @@ Config:
 - `escape_models`: custom escape/capture rules
 - `escape_max_depth`: helper call depth for origin tracking (default: 3)
 - `resource_models` of kind `alloc` are used to treat allocator-backed values as heap
+
+Custom escape models use the same shared call resolution as resource models, including identifier calls, receiver method calls, receiver types, and FQNs.
 
 Notes:
 - `try std.Thread.spawn(...)` ignores the `try_error` edge when checking join guarantees (no thread is created on the error path).

--- a/src/analysis/call_resolver.zig
+++ b/src/analysis/call_resolver.zig
@@ -1,0 +1,887 @@
+const std = @import("std");
+const import_resolver = @import("import_resolver.zig");
+const TypeContext = @import("../type_context.zig").TypeContext;
+const TypeInfo = @import("../zir_bridge.zig").TypeInfo;
+
+pub const ResolvedType = struct {
+    file_index: usize,
+    type_name: ?[]const u8 = null,
+};
+
+pub const CallInfo = struct {
+    call_node: u32,
+    method_name: []const u8,
+    receiver_type: ?[]const u8,
+    fqn: ?[]const u8,
+    base_node: ?u32,
+    param_count: usize,
+};
+
+pub fn isCallNode(tag: std.zig.Ast.Node.Tag) bool {
+    return tag == .call or tag == .call_comma or tag == .call_one or tag == .call_one_comma;
+}
+
+pub fn resolveCall(
+    tree: *const std.zig.Ast,
+    type_ctx: ?*TypeContext,
+    call_node: u32,
+    fqn_buffer: *[256]u8,
+) ?CallInfo {
+    const tags = tree.nodes.items(.tag);
+    const datas = tree.nodes.items(.data);
+    const token_tags = tree.tokens.items(.tag);
+
+    if (call_node >= tags.len or !isCallNode(tags[call_node])) return null;
+
+    var call_buf: [1]std.zig.Ast.Node.Index = undefined;
+    const full_call = tree.fullCall(&call_buf, @enumFromInt(call_node)) orelse return null;
+    const callee_node: u32 = @intFromEnum(full_call.ast.fn_expr);
+    if (callee_node >= tags.len) return null;
+
+    return switch (tags[callee_node]) {
+        .identifier => blk: {
+            const token = tree.nodes.items(.main_token)[callee_node];
+            if (token >= token_tags.len or token_tags[token] != .identifier) return null;
+            const name = tree.tokenSlice(token);
+            break :blk .{
+                .call_node = call_node,
+                .method_name = name,
+                .receiver_type = null,
+                .fqn = name,
+                .base_node = null,
+                .param_count = full_call.ast.params.len,
+            };
+        },
+        .field_access => blk: {
+            const field_access_data = datas[callee_node].node_and_token;
+            const base_node = @intFromEnum(field_access_data[0]);
+            const field_token = field_access_data[1];
+            if (field_token >= token_tags.len or token_tags[field_token] != .identifier) return null;
+            const field_name = tree.tokenSlice(field_token);
+            const receiver_type = getReceiverTypeName(type_ctx, tree, base_node);
+            const fqn = constructFqn(tree, base_node, field_name, fqn_buffer);
+            break :blk .{
+                .call_node = call_node,
+                .method_name = field_name,
+                .receiver_type = receiver_type,
+                .fqn = fqn,
+                .base_node = base_node,
+                .param_count = full_call.ast.params.len,
+            };
+        },
+        else => null,
+    };
+}
+
+pub fn callParam(tree: *const std.zig.Ast, call_node: u32, index: usize) ?u32 {
+    const tags = tree.nodes.items(.tag);
+    if (call_node >= tags.len or !isCallNode(tags[call_node])) return null;
+
+    var call_buf: [1]std.zig.Ast.Node.Index = undefined;
+    const full_call = tree.fullCall(&call_buf, @enumFromInt(call_node)) orelse return null;
+    if (index >= full_call.ast.params.len) return null;
+    return @intFromEnum(full_call.ast.params[index]);
+}
+
+pub fn getReceiverTypeName(type_ctx: ?*TypeContext, tree: *const std.zig.Ast, base_node: u32) ?[]const u8 {
+    const ctx = type_ctx orelse return null;
+    const tags = tree.nodes.items(.tag);
+    if (base_node >= tags.len) return null;
+    if (ctx.getExpressionType(base_node)) |ti| {
+        return ti.type_str;
+    }
+    return null;
+}
+
+pub fn constructFqn(
+    tree: *const std.zig.Ast,
+    base_node: u32,
+    method_name: []const u8,
+    buffer: *[256]u8,
+) ?[]const u8 {
+    const tags = tree.nodes.items(.tag);
+    const datas = tree.nodes.items(.data);
+    const main_tokens = tree.nodes.items(.main_token);
+    const token_tags = tree.tokens.items(.tag);
+
+    var parts: [16][]const u8 = undefined;
+    var count: usize = 0;
+    var node = base_node;
+
+    while (true) {
+        if (node >= tags.len) return null;
+
+        switch (tags[node]) {
+            .identifier => {
+                const ident_token = main_tokens[node];
+                if (ident_token >= token_tags.len or token_tags[ident_token] != .identifier) return null;
+                if (count >= parts.len) return null;
+                parts[count] = tree.tokenSlice(ident_token);
+                count += 1;
+                break;
+            },
+            .field_access => {
+                const field_access = datas[node].node_and_token;
+                const field_token = field_access[1];
+                if (field_token >= token_tags.len or token_tags[field_token] != .identifier) return null;
+                if (count >= parts.len) return null;
+                parts[count] = tree.tokenSlice(field_token);
+                count += 1;
+                node = @intFromEnum(field_access[0]);
+            },
+            else => return null,
+        }
+    }
+
+    var pos: usize = 0;
+    var idx: usize = count;
+    while (idx > 0) : (idx -= 1) {
+        if (!appendFqnPart(buffer, parts[idx - 1], &pos)) return null;
+        if (idx > 1 and !appendFqnSeparator(buffer, &pos)) return null;
+    }
+
+    if (!appendFqnSeparator(buffer, &pos)) return null;
+    if (!appendFqnPart(buffer, method_name, &pos)) return null;
+
+    return buffer[0..pos];
+}
+
+pub fn receiverSourceSlice(source: []const u8, tree: *const std.zig.Ast, node: u32) ?[]const u8 {
+    const range = receiverByteRange(tree, node) orelse return null;
+    if (range.start >= source.len or range.end > source.len or range.start >= range.end) return null;
+    return source[range.start..range.end];
+}
+
+pub fn resolveResultLocationType(
+    tree: *const std.zig.Ast,
+    type_ctx: *TypeContext,
+    parent_map: []const u32,
+    expr_node: u32,
+) ?TypeInfo {
+    const tags = tree.nodes.items(.tag);
+    const datas = tree.nodes.items(.data);
+    const token_tags = tree.tokens.items(.tag);
+
+    var node = expr_node;
+    var depth: u32 = 0;
+    while (node < parent_map.len and depth < 64) : (depth += 1) {
+        const parent = parent_map[node];
+        if (parent == 0 or parent >= tags.len) break;
+
+        switch (tags[parent]) {
+            .grouped_expression, .unwrap_optional, .@"try", .@"catch", .if_simple, .@"if" => {
+                node = parent;
+                continue;
+            },
+            .builtin_call, .builtin_call_comma, .builtin_call_two, .builtin_call_two_comma => {
+                if (builtinCallName(tree, tags, token_tags, parent)) |name| {
+                    if (std.mem.eql(u8, name, "@as")) {
+                        var buf: [2]std.zig.Ast.Node.Index = undefined;
+                        const params = tree.builtinCallParams(&buf, @enumFromInt(parent)) orelse return null;
+                        if (params.len < 2) return null;
+                        const type_node = @intFromEnum(params[0]);
+                        const value_node = @intFromEnum(params[1]);
+                        if (!nodeIsAncestor(value_node, expr_node, parent_map)) return null;
+                        if (type_ctx.getTypeFromAstNode(type_node)) |ti| return ti;
+                        return typeInfoFromTypeNode(tree, tags, datas, type_node);
+                    }
+                }
+                return null;
+            },
+            .simple_var_decl, .local_var_decl, .global_var_decl, .aligned_var_decl => {
+                const full = tree.fullVarDecl(@enumFromInt(parent)) orelse return null;
+                if (full.ast.type_node.unwrap()) |type_node| {
+                    if (type_ctx.getTypeFromAstNode(@intFromEnum(type_node))) |ti| return ti;
+                    if (typeInfoFromTypeNode(tree, tags, datas, @intFromEnum(type_node))) |ti| return ti;
+                }
+                if (full.ast.init_node.unwrap()) |init_node| {
+                    if (nodeIsAncestor(@intFromEnum(init_node), expr_node, parent_map)) {
+                        if (type_ctx.getExpressionTypeStrict(@intFromEnum(init_node))) |ti| {
+                            if (!isUnknownTypeInfo(ti)) return ti;
+                        }
+                    }
+                }
+                return null;
+            },
+            .@"return" => {
+                if (findAncestorFn(tags, parent_map, parent)) |fn_node| {
+                    if (type_ctx.getContainingFunctionReturnType(fn_node)) |ti| {
+                        if (!isUnknownTypeInfo(ti)) return ti;
+                    }
+                    if (returnTypeInfoFromFn(tree, tags, datas, fn_node)) |ti| return ti;
+                }
+                return null;
+            },
+            else => {
+                if (isAssignTag(tags[parent])) {
+                    const pair = datas[parent].node_and_node;
+                    const lhs = @intFromEnum(pair[0]);
+                    const rhs = @intFromEnum(pair[1]);
+                    if (nodeIsAncestor(rhs, expr_node, parent_map)) {
+                        if (type_ctx.getExpressionTypeStrict(lhs)) |ti| {
+                            if (!isUnknownTypeInfo(ti)) return ti;
+                        }
+                    }
+                }
+                return null;
+            },
+        }
+    }
+    return null;
+}
+
+pub const ProjectTypeResolver = struct {
+    files: []const import_resolver.File,
+    file_index: usize,
+
+    fn currentFile(self: ProjectTypeResolver) import_resolver.File {
+        return self.files[self.file_index];
+    }
+
+    pub fn resolveExprType(self: ProjectTypeResolver, node: usize) ?ResolvedType {
+        const tree = self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        switch (tags[node]) {
+            .identifier => {
+                const name = import_resolver.identifierName(tree, node) orelse return null;
+                return self.resolveNameType(name, node);
+            },
+            .field_access => {
+                const datas = tree.nodes.items(.data);
+                const field_access = datas[node].node_and_token;
+                const lhs = @intFromEnum(field_access[0]);
+                const member_name = import_resolver.normalizeIdentifier(tree.tokenSlice(field_access[1]));
+                const base_type = self.resolveExprType(lhs) orelse return null;
+                return self.resolveMemberType(base_type, member_name);
+            },
+            .call,
+            .call_comma,
+            .call_one,
+            .call_one_comma,
+            => return self.resolveCallType(@intCast(node)),
+            .struct_init,
+            .struct_init_comma,
+            .struct_init_one,
+            .struct_init_one_comma,
+            .struct_init_dot,
+            .struct_init_dot_comma,
+            .struct_init_dot_two,
+            .struct_init_dot_two_comma,
+            => return self.resolveStructInitType(@intCast(node)),
+            .builtin_call,
+            .builtin_call_comma,
+            .builtin_call_two,
+            .builtin_call_two_comma,
+            => return self.resolveBuiltinType(@intCast(node)),
+            else => return null,
+        }
+    }
+
+    pub fn resolveTypeNode(self: ProjectTypeResolver, node: usize) ?ResolvedType {
+        const tree = self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        switch (tags[node]) {
+            .identifier => {
+                const name = import_resolver.identifierName(tree, node) orelse return null;
+                return self.resolveNameType(name, node);
+            },
+            .field_access => {
+                const datas = tree.nodes.items(.data);
+                const field_access = datas[node].node_and_token;
+                const lhs = @intFromEnum(field_access[0]);
+                const member_name = import_resolver.normalizeIdentifier(tree.tokenSlice(field_access[1]));
+                const base_type = self.resolveTypeNode(lhs) orelse self.resolveExprType(lhs) orelse return null;
+                return self.resolveMemberType(base_type, member_name);
+            },
+            .ptr_type,
+            .ptr_type_aligned,
+            .ptr_type_bit_range,
+            .ptr_type_sentinel,
+            => {
+                const ptr = tree.fullPtrType(@enumFromInt(node)) orelse return null;
+                return self.resolveTypeNode(@intFromEnum(ptr.ast.child_type));
+            },
+            .optional_type => return self.resolveTypeNode(@intFromEnum(tree.nodes.items(.data)[node].node)),
+            .error_union => return self.resolveTypeNode(@intFromEnum(tree.nodes.items(.data)[node].node_and_node[1])),
+            .builtin_call,
+            .builtin_call_comma,
+            .builtin_call_two,
+            .builtin_call_two_comma,
+            => return self.resolveBuiltinType(@intCast(node)),
+            else => return null,
+        }
+    }
+
+    pub fn varDeclInitializerReferencesExpectedTypeMethod(
+        self: ProjectTypeResolver,
+        full: std.zig.Ast.full.VarDecl,
+        decl_file_index: usize,
+        method_name: []const u8,
+    ) bool {
+        const type_node = full.ast.type_node.unwrap() orelse return false;
+        const expected_type = self.resolveTypeNode(@intFromEnum(type_node)) orelse return false;
+        if (expected_type.file_index != decl_file_index) return false;
+        if (expected_type.type_name != null) return false;
+
+        const init_node = full.ast.init_node.unwrap() orelse return false;
+        return self.initializerReferencesExpectedTypeMethod(@intFromEnum(init_node), method_name);
+    }
+
+    fn resolveNameType(self: ProjectTypeResolver, name: []const u8, reference_node: usize) ?ResolvedType {
+        if (self.resolveNearestBindingType(name, reference_node)) |resolved| return resolved;
+        if (self.resolveNamedDeclType(self.file_index, name)) |resolved| return resolved;
+        if (std.mem.eql(u8, name, import_resolver.fileStem(self.currentFile().path))) {
+            return .{ .file_index = self.file_index };
+        }
+        return null;
+    }
+
+    fn resolveNearestBindingType(self: ProjectTypeResolver, name: []const u8, reference_node: usize) ?ResolvedType {
+        const tree = self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        const reference_start = import_resolver.nodeStart(tree, reference_node) orelse return null;
+
+        var best_start: usize = 0;
+        var best_type: ?ResolvedType = null;
+
+        for (tags, 0..) |tag, node_index| {
+            switch (tag) {
+                .simple_var_decl,
+                .aligned_var_decl,
+                .global_var_decl,
+                .local_var_decl,
+                => {
+                    const full = tree.fullVarDecl(@enumFromInt(node_index)) orelse continue;
+                    const name_token = full.ast.mut_token + 1;
+                    if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
+                    const decl_name = import_resolver.normalizeIdentifier(tree.tokenSlice(name_token));
+                    if (!std.mem.eql(u8, decl_name, name)) continue;
+
+                    const start = tree.tokens.items(.start)[name_token];
+                    if (start > reference_start or start < best_start) continue;
+                    if (self.resolveVarDeclType(full, node_index, decl_name)) |resolved| {
+                        best_start = start;
+                        best_type = resolved;
+                    }
+                },
+                .fn_decl,
+                .fn_proto,
+                .fn_proto_simple,
+                .fn_proto_one,
+                .fn_proto_multi,
+                => {
+                    if (self.resolveFnParamBindingType(@intCast(node_index), name, reference_start, &best_start)) |resolved| {
+                        best_type = resolved;
+                    }
+                },
+                else => {},
+            }
+        }
+
+        return best_type;
+    }
+
+    fn resolveFnParamBindingType(
+        self: ProjectTypeResolver,
+        node: u32,
+        name: []const u8,
+        reference_start: usize,
+        best_start: *usize,
+    ) ?ResolvedType {
+        const tree = self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        if (tags[node] == .fn_decl) {
+            const proto_node = @intFromEnum(tree.nodes.items(.data)[node].node_and_node[0]);
+            return self.resolveFnParamBindingType(@intCast(proto_node), name, reference_start, best_start);
+        }
+
+        var buffer: [1]std.zig.Ast.Node.Index = undefined;
+        const proto = switch (tags[node]) {
+            .fn_proto => tree.fnProto(@enumFromInt(node)),
+            .fn_proto_simple => tree.fnProtoSimple(&buffer, @enumFromInt(node)),
+            .fn_proto_one => tree.fnProtoOne(&buffer, @enumFromInt(node)),
+            .fn_proto_multi => tree.fnProtoMulti(@enumFromInt(node)),
+            else => return null,
+        };
+
+        var best_type: ?ResolvedType = null;
+        for (proto.ast.params) |param_node| {
+            const param_index = @intFromEnum(param_node);
+            if (param_index >= tags.len) continue;
+
+            if (import_resolver.isVarDeclTag(tags[param_index])) {
+                const full = tree.fullVarDecl(param_node) orelse continue;
+                const name_token = full.ast.mut_token + 1;
+                if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
+                const param_name = import_resolver.normalizeIdentifier(tree.tokenSlice(name_token));
+                if (!std.mem.eql(u8, param_name, name)) continue;
+
+                const start = tree.tokens.items(.start)[name_token];
+                if (start > reference_start or start < best_start.*) continue;
+                if (self.resolveVarDeclType(full, param_index, param_name)) |resolved| {
+                    best_start.* = start;
+                    best_type = resolved;
+                }
+                continue;
+            }
+
+            const name_token = import_resolver.paramNameTokenBeforeType(tree, param_index) orelse continue;
+            const param_name = import_resolver.normalizeIdentifier(tree.tokenSlice(@intCast(name_token)));
+            if (!std.mem.eql(u8, param_name, name)) continue;
+
+            const start = tree.tokens.items(.start)[name_token];
+            if (start > reference_start or start < best_start.*) continue;
+            if (self.resolveTypeNode(param_index)) |resolved| {
+                best_start.* = start;
+                best_type = resolved;
+            }
+        }
+        return best_type;
+    }
+
+    fn resolveVarDeclType(
+        self: ProjectTypeResolver,
+        full: std.zig.Ast.full.VarDecl,
+        node_index: usize,
+        decl_name: []const u8,
+    ) ?ResolvedType {
+        if (full.ast.type_node.unwrap()) |type_node| {
+            if (self.resolveTypeNode(@intFromEnum(type_node))) |resolved| return resolved;
+        }
+
+        const init_node = full.ast.init_node.unwrap() orelse return null;
+        const init_index = @intFromEnum(init_node);
+        const tree = self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (init_index >= tags.len) return null;
+        if (import_resolver.isBuiltinCallTag(tags[init_index])) {
+            return self.resolveBuiltinType(@intCast(init_index));
+        }
+        if (isContainerTag(tags[init_index])) {
+            return .{ .file_index = self.file_index, .type_name = decl_name };
+        }
+        if (isRootDeclNode(tree, node_index)) return null;
+        return self.resolveInitializerType(init_index);
+    }
+
+    fn resolveInitializerType(self: ProjectTypeResolver, node: usize) ?ResolvedType {
+        const tree = self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        return switch (tags[node]) {
+            .call, .call_comma, .call_one, .call_one_comma => self.resolveCallType(@intCast(node)),
+            .@"try",
+            .address_of,
+            .deref,
+            .optional_type,
+            => self.resolveInitializerType(@intFromEnum(tree.nodes.items(.data)[node].node)),
+            .grouped_expression,
+            .unwrap_optional,
+            => self.resolveInitializerType(@intFromEnum(tree.nodes.items(.data)[node].node_and_token[0])),
+            .struct_init,
+            .struct_init_comma,
+            .struct_init_one,
+            .struct_init_one_comma,
+            .struct_init_dot,
+            .struct_init_dot_comma,
+            .struct_init_dot_two,
+            .struct_init_dot_two_comma,
+            => self.resolveStructInitType(@intCast(node)),
+            .builtin_call,
+            .builtin_call_comma,
+            .builtin_call_two,
+            .builtin_call_two_comma,
+            => self.resolveBuiltinType(@intCast(node)),
+            else => null,
+        };
+    }
+
+    fn initializerReferencesExpectedTypeMethod(
+        self: ProjectTypeResolver,
+        node: usize,
+        method_name: []const u8,
+    ) bool {
+        const tree = self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return false;
+
+        return switch (tags[node]) {
+            .call,
+            .call_comma,
+            .call_one,
+            .call_one_comma,
+            => self.callUsesImplicitResultMethod(@intCast(node), method_name),
+            .@"try",
+            .address_of,
+            .deref,
+            .optional_type,
+            => self.initializerReferencesExpectedTypeMethod(@intFromEnum(tree.nodes.items(.data)[node].node), method_name),
+            .grouped_expression,
+            .unwrap_optional,
+            => self.initializerReferencesExpectedTypeMethod(@intFromEnum(tree.nodes.items(.data)[node].node_and_token[0]), method_name),
+            .@"catch" => self.initializerReferencesExpectedTypeMethod(@intFromEnum(tree.nodes.items(.data)[node].node_and_node[0]), method_name),
+            else => false,
+        };
+    }
+
+    fn callUsesImplicitResultMethod(self: ProjectTypeResolver, node: u32, method_name: []const u8) bool {
+        const tree = self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return false;
+
+        var buffer: [1]std.zig.Ast.Node.Index = undefined;
+        const call = tree.fullCall(&buffer, @enumFromInt(node)) orelse return false;
+        const callee = @intFromEnum(call.ast.fn_expr);
+        if (callee >= tags.len or tags[callee] != .enum_literal) return false;
+
+        const token = tree.nodes.items(.main_token)[callee];
+        if (token >= tree.tokens.len) return false;
+        return std.mem.eql(u8, import_resolver.normalizeIdentifier(tree.tokenSlice(token)), method_name);
+    }
+
+    fn resolveCallType(self: ProjectTypeResolver, node: u32) ?ResolvedType {
+        const tree = self.currentFile().tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        var buffer: [1]std.zig.Ast.Node.Index = undefined;
+        const call = tree.fullCall(&buffer, @enumFromInt(node)) orelse return null;
+        const callee = @intFromEnum(call.ast.fn_expr);
+        if (callee >= tags.len) return null;
+        if (tags[callee] == .field_access) {
+            const lhs = @intFromEnum(tree.nodes.items(.data)[callee].node_and_token[0]);
+            return self.resolveTypeNode(lhs) orelse self.resolveExprType(lhs);
+        }
+        return null;
+    }
+
+    fn resolveStructInitType(self: ProjectTypeResolver, node: u32) ?ResolvedType {
+        const tree = self.currentFile().tree;
+        var buffer: [2]std.zig.Ast.Node.Index = undefined;
+        const init = tree.fullStructInit(&buffer, @enumFromInt(node)) orelse return null;
+        const type_node = init.ast.type_expr.unwrap() orelse return null;
+        return self.resolveTypeNode(@intFromEnum(type_node));
+    }
+
+    fn resolveBuiltinType(self: ProjectTypeResolver, node: u32) ?ResolvedType {
+        const tree = self.currentFile().tree;
+        if (import_resolver.importPathFromBuiltinCall(tree, node)) |import_path| {
+            if (import_resolver.resolveImportToFileIndex(self.files, self.currentFile().path, import_path)) |file_index| {
+                return .{ .file_index = file_index };
+            }
+        }
+        if (isThisBuiltinCall(tree, node)) {
+            return .{ .file_index = self.file_index };
+        }
+        return null;
+    }
+
+    fn resolveMemberType(self: ProjectTypeResolver, base_type: ResolvedType, member_name: []const u8) ?ResolvedType {
+        const member_resolver = ProjectTypeResolver{
+            .files = self.files,
+            .file_index = base_type.file_index,
+        };
+        if (member_resolver.resolveNamedDeclType(base_type.file_index, member_name)) |resolved| return resolved;
+        return member_resolver.resolveFieldType(base_type, member_name);
+    }
+
+    fn resolveNamedDeclType(self: ProjectTypeResolver, file_index: usize, name: []const u8) ?ResolvedType {
+        const file = self.files[file_index];
+        const tree = file.tree;
+        const tags = tree.nodes.items(.tag);
+
+        for (tree.rootDecls()) |decl_idx| {
+            const node_index = @intFromEnum(decl_idx);
+            if (node_index >= tags.len or !import_resolver.isVarDeclTag(tags[node_index])) continue;
+            const full = tree.fullVarDecl(decl_idx) orelse continue;
+            const name_token = full.ast.mut_token + 1;
+            if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
+            const decl_name = import_resolver.normalizeIdentifier(tree.tokenSlice(name_token));
+            if (!std.mem.eql(u8, decl_name, name)) continue;
+
+            const nested_resolver = ProjectTypeResolver{ .files = self.files, .file_index = file_index };
+            if (nested_resolver.resolveVarDeclType(full, node_index, decl_name)) |resolved| return resolved;
+        }
+        return null;
+    }
+
+    fn resolveFieldType(self: ProjectTypeResolver, base_type: ResolvedType, field_name: []const u8) ?ResolvedType {
+        if (base_type.type_name) |container_name| {
+            if (self.findNamedContainerNode(base_type.file_index, container_name)) |container_node| {
+                return self.resolveContainerFieldType(base_type.file_index, container_node, field_name);
+            }
+        }
+        return self.resolveRootFieldType(base_type.file_index, field_name);
+    }
+
+    fn findNamedContainerNode(self: ProjectTypeResolver, file_index: usize, name: []const u8) ?u32 {
+        const file = self.files[file_index];
+        const tree = file.tree;
+        const tags = tree.nodes.items(.tag);
+
+        for (tree.rootDecls()) |decl_idx| {
+            const node_index = @intFromEnum(decl_idx);
+            if (node_index >= tags.len or !import_resolver.isVarDeclTag(tags[node_index])) continue;
+            const full = tree.fullVarDecl(decl_idx) orelse continue;
+            const name_token = full.ast.mut_token + 1;
+            if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
+            if (!std.mem.eql(u8, import_resolver.normalizeIdentifier(tree.tokenSlice(name_token)), name)) continue;
+            const init_node = full.ast.init_node.unwrap() orelse continue;
+            const init_index = @intFromEnum(init_node);
+            if (init_index < tags.len and isContainerTag(tags[init_index])) return @intCast(init_index);
+        }
+        return null;
+    }
+
+    fn resolveRootFieldType(self: ProjectTypeResolver, file_index: usize, field_name: []const u8) ?ResolvedType {
+        const file = self.files[file_index];
+        const tree = file.tree;
+        const tags = tree.nodes.items(.tag);
+
+        for (tree.rootDecls()) |decl_idx| {
+            const node_index = @intFromEnum(decl_idx);
+            if (node_index >= tags.len) continue;
+            switch (tags[node_index]) {
+                .container_field,
+                .container_field_init,
+                .container_field_align,
+                => if (self.resolveContainerFieldNodeType(file_index, @intCast(node_index), field_name)) |resolved| return resolved,
+                else => {},
+            }
+        }
+        return null;
+    }
+
+    fn resolveContainerFieldType(self: ProjectTypeResolver, file_index: usize, container_node: u32, field_name: []const u8) ?ResolvedType {
+        const file = self.files[file_index];
+        const tree = file.tree;
+
+        var buffer: [2]std.zig.Ast.Node.Index = undefined;
+        const container = tree.fullContainerDecl(&buffer, @enumFromInt(container_node)) orelse return null;
+        for (container.ast.members) |member_node| {
+            const member = @intFromEnum(member_node);
+            if (self.resolveContainerFieldNodeType(file_index, @intCast(member), field_name)) |resolved| return resolved;
+        }
+        return null;
+    }
+
+    fn resolveContainerFieldNodeType(self: ProjectTypeResolver, file_index: usize, node: u32, field_name: []const u8) ?ResolvedType {
+        const file = self.files[file_index];
+        const tree = file.tree;
+        const tags = tree.nodes.items(.tag);
+        if (node >= tags.len) return null;
+
+        const field = tree.fullContainerField(@enumFromInt(node)) orelse return null;
+        if (field.ast.tuple_like) return null;
+        const name_token = field.ast.main_token;
+        if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) return null;
+        if (!std.mem.eql(u8, import_resolver.normalizeIdentifier(tree.tokenSlice(name_token)), field_name)) return null;
+
+        const nested_resolver = ProjectTypeResolver{ .files = self.files, .file_index = file_index };
+        if (field.ast.type_expr.unwrap()) |type_node| {
+            return nested_resolver.resolveTypeNode(@intFromEnum(type_node));
+        }
+        if (field.ast.value_expr.unwrap()) |value_node| {
+            return nested_resolver.resolveInitializerType(@intFromEnum(value_node));
+        }
+        return null;
+    }
+};
+
+pub fn typeInfoFromTypeNode(
+    tree: *const std.zig.Ast,
+    tags: []const std.zig.Ast.Node.Tag,
+    datas: []const std.zig.Ast.Node.Data,
+    type_node: u32,
+) ?TypeInfo {
+    if (type_node >= tags.len) return null;
+    return switch (tags[type_node]) {
+        .error_union => {
+            const pair = datas[type_node].node_and_node;
+            return typeInfoFromTypeNode(tree, tags, datas, @intFromEnum(pair[1]));
+        },
+        .optional_type => {
+            const child = datas[type_node].node;
+            return typeInfoFromTypeNode(tree, tags, datas, @intFromEnum(child));
+        },
+        .ptr_type_sentinel, .ptr_type, .ptr_type_aligned, .ptr_type_bit_range => {
+            if (tree.fullPtrType(@enumFromInt(type_node))) |pt| {
+                const has_sentinel = pt.ast.sentinel != .none;
+                return .{
+                    .kind = if (pt.size == .slice) .slice else .pointer,
+                    .sentinel = if (has_sentinel) .{ .value = 0 } else null,
+                };
+            }
+            return TypeInfo.initPointer();
+        },
+        .slice_sentinel, .array_type_sentinel => TypeInfo{ .kind = .slice, .sentinel = .{ .value = 0 } },
+        .slice, .slice_open => TypeInfo{ .kind = .slice },
+        else => null,
+    };
+}
+
+pub fn isAssignTag(tag: std.zig.Ast.Node.Tag) bool {
+    return switch (tag) {
+        .assign,
+        .assign_mul,
+        .assign_div,
+        .assign_mod,
+        .assign_add,
+        .assign_sub,
+        .assign_shl,
+        .assign_shl_sat,
+        .assign_shr,
+        .assign_bit_and,
+        .assign_bit_xor,
+        .assign_bit_or,
+        .assign_mul_wrap,
+        .assign_add_wrap,
+        .assign_sub_wrap,
+        .assign_mul_sat,
+        .assign_add_sat,
+        .assign_sub_sat,
+        => true,
+        else => false,
+    };
+}
+
+pub fn isContainerTag(tag: std.zig.Ast.Node.Tag) bool {
+    return switch (tag) {
+        .container_decl,
+        .container_decl_trailing,
+        .container_decl_two,
+        .container_decl_two_trailing,
+        .container_decl_arg,
+        .container_decl_arg_trailing,
+        .tagged_union,
+        .tagged_union_trailing,
+        .tagged_union_enum_tag,
+        .tagged_union_enum_tag_trailing,
+        .tagged_union_two,
+        .tagged_union_two_trailing,
+        => true,
+        else => false,
+    };
+}
+
+fn receiverByteRange(tree: *const std.zig.Ast, node: u32) ?struct { start: usize, end: usize } {
+    const tags = tree.nodes.items(.tag);
+    const datas = tree.nodes.items(.data);
+    const main_tokens = tree.nodes.items(.main_token);
+    const token_starts = tree.tokens.items(.start);
+    const token_tags = tree.tokens.items(.tag);
+
+    if (node >= tags.len) return null;
+    switch (tags[node]) {
+        .identifier => {
+            const token = main_tokens[node];
+            if (token >= token_tags.len or token_tags[token] != .identifier) return null;
+            const start = token_starts[token];
+            return .{ .start = start, .end = start + tree.tokenSlice(token).len };
+        },
+        .field_access => {
+            const access = datas[node].node_and_token;
+            const base_range = receiverByteRange(tree, @intFromEnum(access[0])) orelse return null;
+            const field_token = access[1];
+            if (field_token >= token_tags.len or token_tags[field_token] != .identifier) return null;
+            return .{
+                .start = base_range.start,
+                .end = token_starts[field_token] + tree.tokenSlice(field_token).len,
+            };
+        },
+        else => return null,
+    }
+}
+
+fn appendFqnPart(buffer: *[256]u8, part: []const u8, pos: *usize) bool {
+    if (part.len == 0) return false;
+    if (pos.* + part.len > buffer.len) return false;
+    std.mem.copyForwards(u8, buffer[pos.* .. pos.* + part.len], part);
+    pos.* += part.len;
+    return true;
+}
+
+fn appendFqnSeparator(buffer: *[256]u8, pos: *usize) bool {
+    if (pos.* >= buffer.len) return false;
+    buffer[pos.*] = '.';
+    pos.* += 1;
+    return true;
+}
+
+fn builtinCallName(
+    tree: *const std.zig.Ast,
+    tags: []const std.zig.Ast.Node.Tag,
+    token_tags: []const std.zig.Token.Tag,
+    node_idx: u32,
+) ?[]const u8 {
+    if (!import_resolver.isBuiltinCallTag(tags[node_idx])) return null;
+
+    const builtin_token = tree.nodes.items(.main_token)[node_idx];
+    if (builtin_token >= token_tags.len) return null;
+    if (token_tags[builtin_token] != .builtin) return null;
+    return tree.tokenSlice(builtin_token);
+}
+
+fn isUnknownTypeInfo(info: TypeInfo) bool {
+    return info.kind == .unknown and info.type_str == null and !info.hasSentinel();
+}
+
+fn findAncestorFn(tags: []const std.zig.Ast.Node.Tag, parent_map: []const u32, start_node: u32) ?u32 {
+    var node = start_node;
+    var depth: u32 = 0;
+    while (node < parent_map.len and depth < 64) : (depth += 1) {
+        const parent = parent_map[node];
+        if (parent == 0 or parent >= tags.len) return null;
+        if (tags[parent] == .fn_decl) return parent;
+        node = parent;
+    }
+    return null;
+}
+
+fn returnTypeInfoFromFn(
+    tree: *const std.zig.Ast,
+    tags: []const std.zig.Ast.Node.Tag,
+    datas: []const std.zig.Ast.Node.Data,
+    fn_node: u32,
+) ?TypeInfo {
+    if (fn_node >= tags.len or tags[fn_node] != .fn_decl) return null;
+    var buf: [1]std.zig.Ast.Node.Index = undefined;
+    const fn_proto = tree.fullFnProto(&buf, @enumFromInt(fn_node)) orelse return null;
+    const ret_type_node = @intFromEnum(fn_proto.ast.return_type);
+    return typeInfoFromTypeNode(tree, tags, datas, ret_type_node);
+}
+
+fn isRootDeclNode(tree: *const std.zig.Ast, node_index: usize) bool {
+    for (tree.rootDecls()) |decl| {
+        if (@intFromEnum(decl) == node_index) return true;
+    }
+    return false;
+}
+
+fn isThisBuiltinCall(tree: *const std.zig.Ast, node: usize) bool {
+    const main_tokens = tree.nodes.items(.main_token);
+    if (node >= main_tokens.len) return false;
+    const token = main_tokens[node];
+    if (token >= tree.tokens.len) return false;
+    return std.mem.eql(u8, tree.tokenSlice(token), "@This");
+}
+
+fn nodeIsAncestor(ancestor: u32, descendant: u32, parent_map: []const u32) bool {
+    if (ancestor == descendant) return true;
+    var node = descendant;
+    var depth: u32 = 0;
+    while (node < parent_map.len and depth < 256) : (depth += 1) {
+        const parent = parent_map[node];
+        if (parent == 0 or parent >= parent_map.len) return false;
+        if (parent == ancestor) return true;
+        node = parent;
+    }
+    return false;
+}

--- a/src/analysis/call_resolver.zig
+++ b/src/analysis/call_resolver.zig
@@ -146,12 +146,6 @@ pub fn constructFqn(
     return buffer[0..pos];
 }
 
-pub fn receiverSourceSlice(source: []const u8, tree: *const std.zig.Ast, node: u32) ?[]const u8 {
-    const range = receiverByteRange(tree, node) orelse return null;
-    if (range.start >= source.len or range.end > source.len or range.start >= range.end) return null;
-    return source[range.start..range.end];
-}
-
 pub fn resolveResultLocationType(
     tree: *const std.zig.Ast,
     type_ctx: *TypeContext,
@@ -769,35 +763,6 @@ pub fn isContainerTag(tag: std.zig.Ast.Node.Tag) bool {
         => true,
         else => false,
     };
-}
-
-fn receiverByteRange(tree: *const std.zig.Ast, node: u32) ?struct { start: usize, end: usize } {
-    const tags = tree.nodes.items(.tag);
-    const datas = tree.nodes.items(.data);
-    const main_tokens = tree.nodes.items(.main_token);
-    const token_starts = tree.tokens.items(.start);
-    const token_tags = tree.tokens.items(.tag);
-
-    if (node >= tags.len) return null;
-    switch (tags[node]) {
-        .identifier => {
-            const token = main_tokens[node];
-            if (token >= token_tags.len or token_tags[token] != .identifier) return null;
-            const start = token_starts[token];
-            return .{ .start = start, .end = start + tree.tokenSlice(token).len };
-        },
-        .field_access => {
-            const access = datas[node].node_and_token;
-            const base_range = receiverByteRange(tree, @intFromEnum(access[0])) orelse return null;
-            const field_token = access[1];
-            if (field_token >= token_tags.len or token_tags[field_token] != .identifier) return null;
-            return .{
-                .start = base_range.start,
-                .end = token_starts[field_token] + tree.tokenSlice(field_token).len,
-            };
-        },
-        else => return null,
-    }
 }
 
 fn appendFqnPart(buffer: *[256]u8, part: []const u8, pos: *usize) bool {

--- a/src/analysis/call_utils.zig
+++ b/src/analysis/call_utils.zig
@@ -24,10 +24,6 @@ pub fn callParam(tree: *const std.zig.Ast, call_node: u32, index: usize) ?u32 {
     return call_resolver.callParam(tree, call_node, index);
 }
 
-pub fn receiverSourceSlice(source: []const u8, tree: *const std.zig.Ast, node: u32) ?[]const u8 {
-    return call_resolver.receiverSourceSlice(source, tree, node);
-}
-
 pub fn resolveResultLocationType(
     tree: *const std.zig.Ast,
     type_ctx: *TypeContext,

--- a/src/analysis/call_utils.zig
+++ b/src/analysis/call_utils.zig
@@ -1,86 +1,38 @@
 const std = @import("std");
+const call_resolver = @import("call_resolver.zig");
 const TypeContext = @import("../type_context.zig").TypeContext;
+const TypeInfo = @import("../zir_bridge.zig").TypeInfo;
+
+pub const CallInfo = call_resolver.CallInfo;
+pub const ProjectTypeResolver = call_resolver.ProjectTypeResolver;
+pub const ResolvedType = call_resolver.ResolvedType;
 
 pub fn isCallNode(tag: std.zig.Ast.Node.Tag) bool {
-    return tag == .call or tag == .call_comma or tag == .call_one or tag == .call_one_comma;
+    return call_resolver.isCallNode(tag);
 }
 
-pub fn getReceiverTypeName(type_ctx: ?*TypeContext, tree: *const std.zig.Ast, base_node: u32) ?[]const u8 {
-    if (type_ctx == null) return null;
-    const tags = tree.nodes.items(.tag);
-    if (base_node >= tags.len) return null;
-    if (type_ctx.?.getExpressionType(base_node)) |ti| {
-        return ti.type_str;
-    }
-    return null;
-}
-
-pub fn constructFqn(
+pub fn resolveCall(
     tree: *const std.zig.Ast,
-    base_node: u32,
-    method_name: []const u8,
-    buffer: *[256]u8,
-) ?[]const u8 {
-    const tags = tree.nodes.items(.tag);
-    const datas = tree.nodes.items(.data);
-    const main_tokens = tree.nodes.items(.main_token);
-    const token_tags = tree.tokens.items(.tag);
-
-    var parts: [16][]const u8 = undefined;
-    var count: usize = 0;
-    var node = base_node;
-
-    while (true) {
-        if (node >= tags.len) return null;
-
-        switch (tags[node]) {
-            .identifier => {
-                const ident_token = main_tokens[node];
-                if (ident_token >= token_tags.len or token_tags[ident_token] != .identifier) return null;
-                if (count >= parts.len) return null;
-                parts[count] = tree.tokenSlice(ident_token);
-                count += 1;
-                break;
-            },
-            .field_access => {
-                const field_access = datas[node].node_and_token;
-                const field_token = field_access[1];
-                if (field_token >= token_tags.len or token_tags[field_token] != .identifier) return null;
-                if (count >= parts.len) return null;
-                parts[count] = tree.tokenSlice(field_token);
-                count += 1;
-                node = @intFromEnum(field_access[0]);
-            },
-            else => return null,
-        }
-    }
-
-    var pos: usize = 0;
-    var idx: usize = count;
-    while (idx > 0) : (idx -= 1) {
-        if (!appendFqnPart(buffer, parts[idx - 1], &pos)) return null;
-        if (idx > 1) {
-            if (!appendFqnSeparator(buffer, &pos)) return null;
-        }
-    }
-
-    if (!appendFqnSeparator(buffer, &pos)) return null;
-    if (!appendFqnPart(buffer, method_name, &pos)) return null;
-
-    return buffer[0..pos];
+    type_ctx: ?*TypeContext,
+    call_node: u32,
+    fqn_buffer: *[256]u8,
+) ?CallInfo {
+    return call_resolver.resolveCall(tree, type_ctx, call_node, fqn_buffer);
 }
 
-fn appendFqnPart(buffer: *[256]u8, part: []const u8, pos: *usize) bool {
-    if (part.len == 0) return false;
-    if (pos.* + part.len > buffer.len) return false;
-    std.mem.copyForwards(u8, buffer[pos.* .. pos.* + part.len], part);
-    pos.* += part.len;
-    return true;
+pub fn callParam(tree: *const std.zig.Ast, call_node: u32, index: usize) ?u32 {
+    return call_resolver.callParam(tree, call_node, index);
 }
 
-fn appendFqnSeparator(buffer: *[256]u8, pos: *usize) bool {
-    if (pos.* >= buffer.len) return false;
-    buffer[pos.*] = '.';
-    pos.* += 1;
-    return true;
+pub fn receiverSourceSlice(source: []const u8, tree: *const std.zig.Ast, node: u32) ?[]const u8 {
+    return call_resolver.receiverSourceSlice(source, tree, node);
+}
+
+pub fn resolveResultLocationType(
+    tree: *const std.zig.Ast,
+    type_ctx: *TypeContext,
+    parent_map: []const u32,
+    expr_node: u32,
+) ?TypeInfo {
+    return call_resolver.resolveResultLocationType(tree, type_ctx, parent_map, expr_node);
 }

--- a/src/analysis/import_resolver.zig
+++ b/src/analysis/import_resolver.zig
@@ -1,0 +1,471 @@
+const std = @import("std");
+const ast_walk = @import("../ast_walk.zig");
+
+pub const File = struct {
+    path: []const u8,
+    tree: *const std.zig.Ast,
+};
+
+pub fn findFileIndexByPath(files: []const File, path: []const u8) ?usize {
+    for (files, 0..) |file, file_index| {
+        if (std.mem.eql(u8, file.path, path) or pathsEquivalent(file.path, path)) return file_index;
+    }
+    return null;
+}
+
+pub fn filePubliclyImportsPath(files: []const File, file_index: usize, target_path: []const u8) bool {
+    if (file_index >= files.len) return false;
+
+    const file = files[file_index];
+    const tags = file.tree.nodes.items(.tag);
+
+    for (file.tree.rootDecls()) |decl_idx| {
+        const idx = @intFromEnum(decl_idx);
+        if (idx >= tags.len) continue;
+        if (!isVarDeclTag(tags[idx])) continue;
+        if (publicVarDeclImportsPath(file.tree, @intCast(idx), file.path, target_path)) return true;
+    }
+    return publicUsingnamespaceImportsPath(files, file.tree, file.path, target_path);
+}
+
+pub fn nodeImportsPath(
+    files: []const File,
+    tree: *const std.zig.Ast,
+    node: usize,
+    importer_path: []const u8,
+    target_path: []const u8,
+) bool {
+    const tags = tree.nodes.items(.tag);
+    if (node >= tags.len) return false;
+
+    switch (tags[node]) {
+        .identifier => {
+            const name = identifierName(tree, node) orelse return false;
+            return importAliasResolvesToPath(tree, importer_path, name, target_path);
+        },
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => {
+            const import_path = importPathFromBuiltinCall(tree, node) orelse return false;
+            return importMayResolveToPath(importer_path, import_path, target_path);
+        },
+        .field_access => {
+            const datas = tree.nodes.items(.data);
+            const lhs = @intFromEnum(datas[node].node_and_token[0]);
+            const field_name = normalizeIdentifier(tree.tokenSlice(datas[node].node_and_token[1]));
+
+            for (files, 0..) |candidate, candidate_index| {
+                if (!nodeImportsPath(files, tree, lhs, importer_path, candidate.path)) continue;
+                if (filePublicMemberImportsPath(files, candidate_index, field_name, target_path)) return true;
+            }
+            return false;
+        },
+        else => return false,
+    }
+}
+
+pub fn fileUsingnamespaceImportsPath(
+    files: []const File,
+    tree: *const std.zig.Ast,
+    importer_path: []const u8,
+    target_path: []const u8,
+) bool {
+    const token_tags = tree.tokens.items(.tag);
+
+    for (token_tags, 0..) |_, token_index| {
+        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(token_index)), "usingnamespace")) continue;
+
+        const import_token = nextNonCommentToken(token_tags, token_index + 1) orelse continue;
+        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(import_token)), "@import")) continue;
+
+        const import_path = importPathFromBuiltinToken(tree, import_token) orelse continue;
+        if (importMayResolveToPath(importer_path, import_path, target_path)) return true;
+        if (resolveImportToFileIndex(files, importer_path, import_path)) |file_index| {
+            if (filePubliclyImportsPath(files, file_index, target_path)) return true;
+        }
+    }
+
+    return false;
+}
+
+pub fn publicUsingnamespaceImportsPath(
+    files: []const File,
+    tree: *const std.zig.Ast,
+    importer_path: []const u8,
+    target_path: []const u8,
+) bool {
+    const token_tags = tree.tokens.items(.tag);
+
+    for (token_tags, 0..) |_, token_index| {
+        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(token_index)), "usingnamespace")) continue;
+
+        const pub_token = prevNonCommentToken(token_tags, token_index) orelse continue;
+        if (tree.tokenTag(@intCast(pub_token)) != .keyword_pub) continue;
+
+        const import_token = nextNonCommentToken(token_tags, token_index + 1) orelse continue;
+        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(import_token)), "@import")) continue;
+
+        const import_path = importPathFromBuiltinToken(tree, import_token) orelse continue;
+        if (importMayResolveToPath(importer_path, import_path, target_path)) return true;
+        if (resolveImportToFileIndex(files, importer_path, import_path)) |file_index| {
+            if (filePubliclyImportsPath(files, file_index, target_path)) return true;
+        }
+    }
+
+    return false;
+}
+
+pub fn initNodeImportsPath(
+    tree: *const std.zig.Ast,
+    node: usize,
+    importer_path: []const u8,
+    target_path: []const u8,
+) bool {
+    const tags = tree.nodes.items(.tag);
+    if (node >= tags.len) return false;
+
+    switch (tags[node]) {
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => {
+            const import_path = importPathFromBuiltinCall(tree, node) orelse return false;
+            return importMayResolveToPath(importer_path, import_path, target_path);
+        },
+        else => {
+            var scanner = ImportPathScanner{
+                .importer_path = importer_path,
+                .target_path = target_path,
+            };
+            ast_walk.walk(ImportPathScanner, tree, @intCast(node), &scanner) catch return false;
+            return scanner.found;
+        },
+    }
+}
+
+pub fn importPathFromBuiltinCall(tree: *const std.zig.Ast, node_idx: usize) ?[]const u8 {
+    const main_tokens = tree.nodes.items(.main_token);
+    if (node_idx >= main_tokens.len) return null;
+    const token = main_tokens[node_idx];
+    if (token >= tree.tokens.len) return null;
+    if (!std.mem.eql(u8, tree.tokenSlice(token), "@import")) return null;
+
+    const token_tags = tree.tokens.items(.tag);
+    var scan_token = token + 1;
+    const end_token = @min(token_tags.len, token + 6);
+    while (scan_token < end_token) : (scan_token += 1) {
+        if (token_tags[scan_token] != .string_literal) continue;
+        const literal = tree.tokenSlice(scan_token);
+        if (literal.len < 2) return null;
+        return literal[1 .. literal.len - 1];
+    }
+    return null;
+}
+
+pub fn importPathFromBuiltinToken(tree: *const std.zig.Ast, token: usize) ?[]const u8 {
+    const token_tags = tree.tokens.items(.tag);
+    const l_paren = nextNonCommentToken(token_tags, token + 1) orelse return null;
+    if (token_tags[l_paren] != .l_paren) return null;
+
+    const string_token = nextNonCommentToken(token_tags, l_paren + 1) orelse return null;
+    if (token_tags[string_token] != .string_literal) return null;
+
+    const literal = tree.tokenSlice(@intCast(string_token));
+    if (literal.len < 2) return null;
+    return literal[1 .. literal.len - 1];
+}
+
+pub fn importResolvesToPath(importer_path: []const u8, import_path: []const u8, target_path: []const u8) bool {
+    if (std.mem.eql(u8, import_path, target_path)) return true;
+
+    const importer_dir = std.fs.path.dirname(importer_path) orelse "";
+    if (importer_dir.len == 0) return pathsEquivalent(import_path, target_path);
+
+    var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const resolved = std.fmt.bufPrint(&resolved_buf, "{s}/{s}", .{ importer_dir, import_path }) catch return false;
+    return pathsEquivalent(resolved, target_path);
+}
+
+pub fn importMayResolveToPath(importer_path: []const u8, import_path: []const u8, target_path: []const u8) bool {
+    if (importResolvesToPath(importer_path, import_path, target_path)) return true;
+    return packageImportMayResolveToPath(import_path, target_path);
+}
+
+pub fn resolveImportToFileIndex(files: []const File, importer_path: []const u8, import_path: []const u8) ?usize {
+    for (files, 0..) |file, file_index| {
+        if (importMayResolveToPath(importer_path, import_path, file.path)) return file_index;
+    }
+    return null;
+}
+
+pub fn packageImportMayResolveToPath(import_path: []const u8, target_path: []const u8) bool {
+    if (std.mem.indexOfScalar(u8, import_path, '/') != null) return false;
+    if (std.mem.endsWith(u8, import_path, ".zig")) return false;
+
+    const basename = std.fs.path.basename(target_path);
+    if (!std.mem.endsWith(u8, basename, ".zig")) return false;
+    const stem = basename[0 .. basename.len - ".zig".len];
+    return std.mem.eql(u8, stem, import_path);
+}
+
+pub fn pathsEquivalent(a: []const u8, b: []const u8) bool {
+    var a_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var b_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const normalized_a = normalizePath(&a_buf, a) catch return false;
+    const normalized_b = normalizePath(&b_buf, b) catch return false;
+    return std.mem.eql(u8, normalized_a, normalized_b);
+}
+
+pub fn normalizePath(buffer: []u8, path: []const u8) ![]const u8 {
+    var segments: [128][]const u8 = undefined;
+    var segment_count: usize = 0;
+
+    var rest = path;
+    while (rest.len > 0) {
+        const slash_index = std.mem.indexOfScalar(u8, rest, '/') orelse rest.len;
+        const segment = rest[0..slash_index];
+        if (segment.len != 0 and !std.mem.eql(u8, segment, ".")) {
+            if (std.mem.eql(u8, segment, "..") and segment_count > 0) {
+                segment_count -= 1;
+            } else {
+                if (segment_count >= segments.len) return error.PathTooManySegments;
+                segments[segment_count] = segment;
+                segment_count += 1;
+            }
+        }
+        if (slash_index == rest.len) break;
+        rest = rest[slash_index + 1 ..];
+    }
+
+    var len: usize = 0;
+    for (segments[0..segment_count]) |segment| {
+        if (len != 0) {
+            if (len >= buffer.len) return error.PathTooLong;
+            buffer[len] = '/';
+            len += 1;
+        }
+        if (len + segment.len > buffer.len) return error.PathTooLong;
+        @memcpy(buffer[len..][0..segment.len], segment);
+        len += segment.len;
+    }
+
+    return buffer[0..len];
+}
+
+pub fn normalizeIdentifier(ident: []const u8) []const u8 {
+    if (ident.len >= 3 and std.mem.startsWith(u8, ident, "@\"") and ident[ident.len - 1] == '"') {
+        return ident[2 .. ident.len - 1];
+    }
+    return ident;
+}
+
+pub fn fileStem(path: []const u8) []const u8 {
+    const basename = std.fs.path.basename(path);
+    if (std.mem.endsWith(u8, basename, ".zig")) return basename[0 .. basename.len - ".zig".len];
+    return basename;
+}
+
+pub fn nodeStart(tree: *const std.zig.Ast, node: usize) ?usize {
+    const main_tokens = tree.nodes.items(.main_token);
+    if (node >= main_tokens.len) return null;
+    const token = main_tokens[node];
+    if (token >= tree.tokens.len) return null;
+    return tree.tokens.items(.start)[token];
+}
+
+pub fn isVarDeclTag(tag: std.zig.Ast.Node.Tag) bool {
+    return switch (tag) {
+        .simple_var_decl,
+        .aligned_var_decl,
+        .global_var_decl,
+        .local_var_decl,
+        => true,
+        else => false,
+    };
+}
+
+pub fn isBuiltinCallTag(tag: std.zig.Ast.Node.Tag) bool {
+    return switch (tag) {
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => true,
+        else => false,
+    };
+}
+
+pub fn nextNonCommentToken(token_tags: []const std.zig.Token.Tag, start: usize) ?usize {
+    var index = start;
+    while (index < token_tags.len) : (index += 1) {
+        switch (token_tags[index]) {
+            .container_doc_comment, .doc_comment => continue,
+            else => return index,
+        }
+    }
+    return null;
+}
+
+pub fn prevNonCommentToken(token_tags: []const std.zig.Token.Tag, start: usize) ?usize {
+    if (start == 0) return null;
+    var index = start - 1;
+    while (true) {
+        switch (token_tags[index]) {
+            .container_doc_comment, .doc_comment => {},
+            else => return index,
+        }
+        if (index == 0) return null;
+        index -= 1;
+    }
+}
+
+pub fn paramNameTokenBeforeType(tree: *const std.zig.Ast, type_node: usize) ?usize {
+    const main_tokens = tree.nodes.items(.main_token);
+    if (type_node >= main_tokens.len) return null;
+    const token_tags = tree.tokens.items(.tag);
+    const type_token = main_tokens[type_node];
+    const colon_token = prevNonCommentToken(token_tags, type_token) orelse return null;
+    if (token_tags[colon_token] != .colon) return null;
+    const name_token = prevNonCommentToken(token_tags, colon_token) orelse return null;
+    if (token_tags[name_token] != .identifier) return null;
+    return name_token;
+}
+
+pub fn identifierName(tree: *const std.zig.Ast, node: usize) ?[]const u8 {
+    const tags = tree.nodes.items(.tag);
+    if (node >= tags.len or tags[node] != .identifier) return null;
+    const main_tokens = tree.nodes.items(.main_token);
+    if (node >= main_tokens.len) return null;
+    return normalizeIdentifier(tree.tokenSlice(main_tokens[node]));
+}
+
+pub fn fieldAccessName(tree: *const std.zig.Ast, node: usize) ?[]const u8 {
+    const tags = tree.nodes.items(.tag);
+    if (node >= tags.len or tags[node] != .field_access) return null;
+    const datas = tree.nodes.items(.data);
+    return normalizeIdentifier(tree.tokenSlice(datas[node].node_and_token[1]));
+}
+
+fn publicVarDeclImportsPath(
+    tree: *const std.zig.Ast,
+    node_idx: u32,
+    importer_path: []const u8,
+    target_path: []const u8,
+) bool {
+    const full = tree.fullVarDecl(@enumFromInt(node_idx)) orelse return false;
+    if (!isPubToken(tree, full.visib_token)) return false;
+
+    const init_node = full.ast.init_node.unwrap() orelse return false;
+    const init_idx = @intFromEnum(init_node);
+    const tags = tree.nodes.items(.tag);
+    if (init_idx >= tags.len) return false;
+
+    switch (tags[init_idx]) {
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => {
+            const import_path = importPathFromBuiltinCall(tree, init_idx) orelse return false;
+            return importMayResolveToPath(importer_path, import_path, target_path);
+        },
+        else => return false,
+    }
+}
+
+fn importAliasResolvesToPath(
+    tree: *const std.zig.Ast,
+    importer_path: []const u8,
+    alias_name: []const u8,
+    target_path: []const u8,
+) bool {
+    const tags = tree.nodes.items(.tag);
+
+    for (tags, 0..) |tag, node_index| {
+        if (!isVarDeclTag(tag)) continue;
+        const full = tree.fullVarDecl(@enumFromInt(node_index)) orelse continue;
+        const name_token = full.ast.mut_token + 1;
+        if (name_token >= tree.tokens.len) continue;
+        if (tree.tokenTag(name_token) != .identifier) continue;
+
+        const name = normalizeIdentifier(tree.tokenSlice(name_token));
+        if (!std.mem.eql(u8, name, alias_name)) continue;
+
+        const init_node = full.ast.init_node.unwrap() orelse continue;
+        if (initNodeImportsPath(tree, @intFromEnum(init_node), importer_path, target_path)) return true;
+    }
+
+    return false;
+}
+
+fn filePublicMemberImportsPath(files: []const File, file_index: usize, member_name: []const u8, target_path: []const u8) bool {
+    if (file_index >= files.len) return false;
+    const file = files[file_index];
+    const tags = file.tree.nodes.items(.tag);
+
+    for (file.tree.rootDecls()) |decl_idx| {
+        const idx = @intFromEnum(decl_idx);
+        if (idx >= tags.len) continue;
+        if (!isVarDeclTag(tags[idx])) continue;
+        if (publicVarDeclNamedImportsPath(file.tree, @intCast(idx), file.path, member_name, target_path)) return true;
+    }
+    return false;
+}
+
+fn publicVarDeclNamedImportsPath(
+    tree: *const std.zig.Ast,
+    node_idx: u32,
+    importer_path: []const u8,
+    expected_name: []const u8,
+    target_path: []const u8,
+) bool {
+    const full = tree.fullVarDecl(@enumFromInt(node_idx)) orelse return false;
+    if (!isPubToken(tree, full.visib_token)) return false;
+
+    const name_token = full.ast.mut_token + 1;
+    if (name_token >= tree.tokens.len) return false;
+    if (tree.tokenTag(name_token) != .identifier) return false;
+    const name = normalizeIdentifier(tree.tokenSlice(name_token));
+    if (!std.mem.eql(u8, name, expected_name)) return false;
+
+    const init_node = full.ast.init_node.unwrap() orelse return false;
+    const import_path = importPathFromBuiltinCall(tree, @intFromEnum(init_node)) orelse return false;
+    return importMayResolveToPath(importer_path, import_path, target_path);
+}
+
+fn isPubToken(tree: *const std.zig.Ast, token: ?std.zig.Ast.TokenIndex) bool {
+    const tok = token orelse return false;
+    return tree.tokenTag(tok) == .keyword_pub;
+}
+
+const ImportPathScanner = struct {
+    importer_path: []const u8,
+    target_path: []const u8,
+    found: bool = false,
+    stop: bool = false,
+
+    pub fn visit(
+        self: *ImportPathScanner,
+        tree: *const std.zig.Ast,
+        node: u32,
+        tag: std.zig.Ast.Node.Tag,
+    ) anyerror!void {
+        switch (tag) {
+            .builtin_call,
+            .builtin_call_comma,
+            .builtin_call_two,
+            .builtin_call_two_comma,
+            => {
+                const import_path = importPathFromBuiltinCall(tree, node) orelse return;
+                if (importMayResolveToPath(self.importer_path, import_path, self.target_path)) {
+                    self.found = true;
+                    self.stop = true;
+                }
+            },
+            else => {},
+        }
+    }
+};

--- a/src/checkers/stack_escape_engine.zig
+++ b/src/checkers/stack_escape_engine.zig
@@ -116,14 +116,7 @@ pub const StackEscapeEngineChecker = struct {
         }
     };
 
-    const CallInfo = struct {
-        call_node: u32,
-        method_name: []const u8,
-        receiver_type: ?[]const u8,
-        fqn: ?[]const u8,
-        params: []const std.zig.Ast.Node.Index,
-        base_node: ?u32,
-    };
+    const CallInfo = call_utils.CallInfo;
 
     const EscapeMatch = struct {
         param_indices: []const u32,
@@ -751,8 +744,7 @@ pub const StackEscapeEngineChecker = struct {
         }
 
         for (match.param_indices) |param_index| {
-            if (param_index >= call_info.params.len) continue;
-            const param_node = @intFromEnum(call_info.params[param_index]);
+            const param_node = call_utils.callParam(ctx.tree, call_info.call_node, @intCast(param_index)) orelse continue;
             const origin = originOfExpr(ctx, state, param_node, ctx.helper_depth);
             if (origin.kind != .stack) continue;
 
@@ -899,52 +891,7 @@ pub const StackEscapeEngineChecker = struct {
     }
 
     fn resolveCallInfo(ctx: *AnalysisContext, call_node: u32) ?CallInfo {
-        const tree = ctx.tree;
-        const tags = tree.nodes.items(.tag);
-        const datas = tree.nodes.items(.data);
-        const token_tags = tree.tokens.items(.tag);
-
-        if (call_node >= tags.len) return null;
-        if (!call_utils.isCallNode(tags[call_node])) return null;
-
-        var call_buf: [1]std.zig.Ast.Node.Index = undefined;
-        const full_call = tree.fullCall(&call_buf, @enumFromInt(call_node)) orelse return null;
-        const callee_node: u32 = @intFromEnum(full_call.ast.fn_expr);
-        if (callee_node >= tags.len) return null;
-
-        switch (tags[callee_node]) {
-            .identifier => {
-                const token = tree.nodes.items(.main_token)[callee_node];
-                if (token >= token_tags.len or token_tags[token] != .identifier) return null;
-                const name = tree.tokenSlice(token);
-                return .{
-                    .call_node = call_node,
-                    .method_name = name,
-                    .receiver_type = null,
-                    .fqn = name,
-                    .params = full_call.ast.params,
-                    .base_node = null,
-                };
-            },
-            .field_access => {
-                const field_access_data = datas[callee_node].node_and_token;
-                const base_node = @intFromEnum(field_access_data[0]);
-                const field_token = field_access_data[1];
-                if (field_token >= token_tags.len or token_tags[field_token] != .identifier) return null;
-                const field_name = tree.tokenSlice(field_token);
-                const receiver_type = call_utils.getReceiverTypeName(ctx.type_ctx, ctx.tree, base_node);
-                const fqn = call_utils.constructFqn(ctx.tree, base_node, field_name, ctx.fqn_buffer);
-                return .{
-                    .call_node = call_node,
-                    .method_name = field_name,
-                    .receiver_type = receiver_type,
-                    .fqn = fqn,
-                    .params = full_call.ast.params,
-                    .base_node = base_node,
-                };
-            },
-            else => return null,
-        }
+        return call_utils.resolveCall(ctx.tree, ctx.type_ctx, call_node, ctx.fqn_buffer);
     }
 
     fn isThreadSpawnCall(ctx: *AnalysisContext, call_node: u32) bool {
@@ -1268,8 +1215,7 @@ pub const StackEscapeEngineChecker = struct {
 
         if (depth > 0) {
             if (resolveHelperReturnParamIndex(ctx, call_info)) |param_index| {
-                if (param_index < call_info.params.len) {
-                    const arg_node = @intFromEnum(call_info.params[param_index]);
+                if (call_utils.callParam(ctx.tree, call_info.call_node, @intCast(param_index))) |arg_node| {
                     return originOfExpr(ctx, state, arg_node, depth - 1);
                 }
             }
@@ -1288,8 +1234,7 @@ pub const StackEscapeEngineChecker = struct {
         var combined = Origin.unknown();
         var has_any = false;
         for (param_indices) |param_index| {
-            if (param_index >= call_info.params.len) continue;
-            const arg_node = @intFromEnum(call_info.params[param_index]);
+            const arg_node = call_utils.callParam(ctx.tree, call_info.call_node, @intCast(param_index)) orelse continue;
             const origin = originOfExpr(ctx, state, arg_node, depth);
             combined = if (!has_any) origin else mergeOrigin(combined, origin);
             has_any = true;
@@ -2027,8 +1972,7 @@ pub const StackEscapeEngineChecker = struct {
 
     fn isAllocPrintCall(ctx: *AnalysisContext, call_info: CallInfo) bool {
         if (!std.mem.eql(u8, call_info.method_name, "allocPrint")) return false;
-        if (call_info.params.len == 0) return false;
-        const allocator_arg = @intFromEnum(call_info.params[0]);
+        const allocator_arg = call_utils.callParam(ctx.tree, call_info.call_node, 0) orelse return false;
         return allocator_utils.isAllocatorExpr(ctx.tree, ctx.type_ctx, allocator_arg);
     }
 };

--- a/src/engine/analysis/resource_calls.zig
+++ b/src/engine/analysis/resource_calls.zig
@@ -58,30 +58,12 @@ pub fn mixin(comptime _Engine: type) type {
 
         pub fn resolveResourceCallFromCall(self: *_Engine, tree: *const std.zig.Ast, call_ast_node: u32) ?ResourceCall {
             const tags = tree.nodes.items(.tag);
-            const datas = tree.nodes.items(.data);
-            const token_tags = tree.tokens.items(.tag);
 
             if (call_ast_node >= tags.len) return null;
-            const tag = tags[call_ast_node];
+            const call_info = call_utils.resolveCall(tree, self.type_context, call_ast_node, &self.fqn_buffer) orelse return null;
 
-            var call_buf: [1]std.zig.Ast.Node.Index = undefined;
-            const full_call = switch (tag) {
-                .call, .call_comma, .call_one, .call_one_comma => tree.fullCall(&call_buf, @enumFromInt(call_ast_node)),
-                else => return null,
-            } orelse return null;
-
-            const callee_node: u32 = @intFromEnum(full_call.ast.fn_expr);
-            if (callee_node >= tags.len) return null;
-            if (tags[callee_node] != .field_access) return null;
-
-            const field_access_data = datas[callee_node].node_and_token;
-            const base_node = @intFromEnum(field_access_data[0]);
-            const field_token = field_access_data[1];
-            if (field_token >= token_tags.len or token_tags[field_token] != .identifier) return null;
-            const field_name = tree.tokenSlice(field_token);
-
-            const first_arg: ?u32 = if (full_call.ast.params.len > 0)
-                @intFromEnum(full_call.ast.params[0])
+            const first_arg: ?u32 = if (call_info.param_count > 0)
+                call_utils.callParam(tree, call_ast_node, 0)
             else
                 null;
 
@@ -95,14 +77,8 @@ pub fn mixin(comptime _Engine: type) type {
                     }
                 }
 
-                // Extract receiver type from the base expression
-                const receiver_type = call_utils.getReceiverTypeName(self.type_context, tree, base_node);
-
-                // Construct FQN from receiver.method
-                const fqn = call_utils.constructFqn(tree, base_node, field_name, &self.fqn_buffer);
-
                 // Match against config resource models
-                if (config.matchResourceModel(field_name, receiver_type, return_type_str, fqn)) |model_kind| {
+                if (config.matchResourceModel(call_info.method_name, call_info.receiver_type, return_type_str, call_info.fqn)) |model_kind| {
                     const kind: ResourceCallKind = switch (model_kind) {
                         .alloc => .alloc,
                         .free => .free,
@@ -111,8 +87,8 @@ pub fn mixin(comptime _Engine: type) type {
                         .close => .close,
                     };
                     const target_expr: ?u32 = switch (kind) {
-                        .free, .close => first_arg orelse base_node,
-                        .free_owned => base_node,
+                        .free, .close => if (first_arg) |arg| arg else call_info.base_node,
+                        .free_owned => if (call_info.base_node) |base| base else first_arg,
                         else => null,
                     };
                     return .{ .kind = kind, .target_expr = target_expr, .call_node = call_ast_node };
@@ -120,19 +96,21 @@ pub fn mixin(comptime _Engine: type) type {
             }
 
             // Priority 2: Built-in heuristics (allocator methods)
-            if (allocator_utils.isAllocatorExpr(tree, self.type_context, base_node)) {
-                if (std.mem.eql(u8, field_name, "alloc") or
-                    std.mem.eql(u8, field_name, "dupe") or
-                    std.mem.eql(u8, field_name, "create"))
-                {
-                    return .{ .kind = .alloc, .target_expr = null, .call_node = call_ast_node };
-                }
-                if (std.mem.eql(u8, field_name, "free") or std.mem.eql(u8, field_name, "destroy")) {
-                    return .{ .kind = .free, .target_expr = first_arg, .call_node = call_ast_node };
+            if (call_info.base_node) |base_node| {
+                if (allocator_utils.isAllocatorExpr(tree, self.type_context, base_node)) {
+                    if (std.mem.eql(u8, call_info.method_name, "alloc") or
+                        std.mem.eql(u8, call_info.method_name, "dupe") or
+                        std.mem.eql(u8, call_info.method_name, "create"))
+                    {
+                        return .{ .kind = .alloc, .target_expr = null, .call_node = call_ast_node };
+                    }
+                    if (std.mem.eql(u8, call_info.method_name, "free") or std.mem.eql(u8, call_info.method_name, "destroy")) {
+                        return .{ .kind = .free, .target_expr = first_arg, .call_node = call_ast_node };
+                    }
                 }
             }
 
-            if (std.mem.eql(u8, field_name, "allocPrint")) {
+            if (std.mem.eql(u8, call_info.method_name, "allocPrint")) {
                 if (first_arg) |arg_node| {
                     if (allocator_utils.isAllocatorExpr(tree, self.type_context, arg_node)) {
                         return .{ .kind = .alloc, .target_expr = null, .call_node = call_ast_node };
@@ -148,19 +126,21 @@ pub fn mixin(comptime _Engine: type) type {
 
             // Priority 4: Name-based open detection with known base types (only when type info is missing).
             if (type_status == .unknown) {
-                if ((std.mem.eql(u8, field_name, "open") or
-                    std.mem.eql(u8, field_name, "openFile") or
-                    std.mem.eql(u8, field_name, "openDir") or
-                    std.mem.eql(u8, field_name, "openIterableDir") or
-                    std.mem.eql(u8, field_name, "createFile")) and
-                    isKnownOpenBase(self, tree, base_node))
-                {
-                    return .{ .kind = .open, .target_expr = null, .call_node = call_ast_node };
+                if (call_info.base_node) |base_node| {
+                    if ((std.mem.eql(u8, call_info.method_name, "open") or
+                        std.mem.eql(u8, call_info.method_name, "openFile") or
+                        std.mem.eql(u8, call_info.method_name, "openDir") or
+                        std.mem.eql(u8, call_info.method_name, "openIterableDir") or
+                        std.mem.eql(u8, call_info.method_name, "createFile")) and
+                        isKnownOpenBase(self, tree, base_node))
+                    {
+                        return .{ .kind = .open, .target_expr = null, .call_node = call_ast_node };
+                    }
                 }
             }
 
-            if (std.mem.eql(u8, field_name, "close")) {
-                const target_expr = first_arg orelse base_node;
+            if (std.mem.eql(u8, call_info.method_name, "close")) {
+                const target_expr: ?u32 = if (first_arg) |arg| arg else call_info.base_node;
                 return .{ .kind = .close, .target_expr = target_expr, .call_node = call_ast_node };
             }
             return null;

--- a/src/engine/analysis/resource_calls.zig
+++ b/src/engine/analysis/resource_calls.zig
@@ -140,8 +140,18 @@ pub fn mixin(comptime _Engine: type) type {
             }
 
             if (std.mem.eql(u8, call_info.method_name, "close")) {
-                const target_expr: ?u32 = if (first_arg) |arg| arg else call_info.base_node;
-                return .{ .kind = .close, .target_expr = target_expr, .call_node = call_ast_node };
+                if (first_arg == null) {
+                    if (call_info.base_node) |base_node| {
+                        return .{ .kind = .close, .target_expr = base_node, .call_node = call_ast_node };
+                    }
+                }
+                if (call_info.fqn) |fqn| {
+                    if (std.mem.eql(u8, fqn, "std.posix.close")) {
+                        if (first_arg) |arg| {
+                            return .{ .kind = .close, .target_expr = arg, .call_node = call_ast_node };
+                        }
+                    }
+                }
             }
             return null;
         }

--- a/src/project_unused_decl.zig
+++ b/src/project_unused_decl.zig
@@ -1,10 +1,18 @@
 const std = @import("std");
 const ast_walk = @import("ast_walk.zig");
+const call_resolver = @import("analysis/call_resolver.zig");
 const Diagnostic = @import("diagnostic.zig").Diagnostic;
+const import_resolver = @import("analysis/import_resolver.zig");
 const Source = @import("source.zig").Source;
 const suppression = @import("suppression.zig");
 
 const rule_id = "unused-decl";
+const fieldAccessName = import_resolver.fieldAccessName;
+const identifierName = import_resolver.identifierName;
+const importPathFromBuiltinCall = import_resolver.importPathFromBuiltinCall;
+const isVarDeclTag = import_resolver.isVarDeclTag;
+const normalizeIdentifier = import_resolver.normalizeIdentifier;
+const pathsEquivalent = import_resolver.pathsEquivalent;
 
 const DeclKind = enum {
     function,
@@ -53,10 +61,10 @@ const DeclInfo = struct {
 
 const ProjectContext = struct {
     allocator: std.mem.Allocator,
-    files: []const FileInfo,
+    files: []const import_resolver.File,
     api_roots: std.ArrayList(usize) = .empty,
 
-    fn init(allocator: std.mem.Allocator, files: []const FileInfo) ProjectContext {
+    fn init(allocator: std.mem.Allocator, files: []const import_resolver.File) ProjectContext {
         return .{
             .allocator = allocator,
             .files = files,
@@ -80,7 +88,7 @@ const ProjectContext = struct {
 
         const target_path = self.files[file_index].path;
         for (self.api_roots.items) |root_index| {
-            if (filePubliclyImportsPath(self.files, &self.files[root_index], target_path)) return true;
+            if (import_resolver.filePubliclyImportsPath(self.files, root_index, target_path)) return true;
         }
         return false;
     }
@@ -98,11 +106,11 @@ const ProjectContext = struct {
     }
 
     fn collectBuildRootSourceFiles(self: *ProjectContext, build_file_index: usize) !void {
-        try self.collectBuildRootSourceFilesFromTree(&self.files[build_file_index].tree, self.files[build_file_index].path);
+        try self.collectBuildRootSourceFilesFromTree(self.files[build_file_index].tree, self.files[build_file_index].path);
     }
 
     fn collectExternalBuildRootSourceFiles(self: *ProjectContext, build_path: []const u8) !void {
-        if (findFileIndexByPath(self.files, build_path) != null) return;
+        if (import_resolver.findFileIndexByPath(self.files, build_path) != null) return;
 
         const file = std.fs.cwd().openFile(build_path, .{}) catch return;
         defer file.close();
@@ -140,18 +148,13 @@ const ProjectContext = struct {
                 const literal = tree.tokenSlice(@intCast(scan_token));
                 if (literal.len < 2) continue;
                 const root_path = literal[1 .. literal.len - 1];
-                if (resolveImportToFileIndex(self.files, build_path, root_path)) |root_index| {
+                if (import_resolver.resolveImportToFileIndex(self.files, build_path, root_path)) |root_index| {
                     try self.appendApiRoot(root_index);
                 }
                 break;
             }
         }
     }
-};
-
-const ResolvedType = struct {
-    file_index: usize,
-    type_name: ?[]const u8 = null,
 };
 
 pub fn analyze(
@@ -201,7 +204,10 @@ pub fn analyze(
 
     if (files.items.len < 2) return;
 
-    var project = ProjectContext.init(allocator, files.items);
+    const resolver_files = try makeResolverFiles(allocator, files.items);
+    defer allocator.free(resolver_files);
+
+    var project = ProjectContext.init(allocator, resolver_files);
     defer project.deinit();
     try project.collectApiRoots();
 
@@ -216,7 +222,7 @@ pub fn analyze(
         try collectPublicRootDecls(allocator, &file.tree, file.path, file_index, &decls);
     }
 
-    const used = try collectProjectUsedDecls(allocator, files.items, decls.items);
+    const used = try collectProjectUsedDecls(allocator, files.items, resolver_files, decls.items);
     defer allocator.free(used);
 
     for (decls.items, 0..) |decl, decl_index| {
@@ -256,6 +262,17 @@ fn findFileIndexByPath(files: []const FileInfo, path: []const u8) ?usize {
         if (std.mem.eql(u8, file.path, path) or pathsEquivalent(file.path, path)) return file_index;
     }
     return null;
+}
+
+fn makeResolverFiles(allocator: std.mem.Allocator, files: []FileInfo) ![]import_resolver.File {
+    const resolver_files = try allocator.alloc(import_resolver.File, files.len);
+    for (files, 0..) |*file, index| {
+        resolver_files[index] = .{
+            .path = file.path,
+            .tree = &file.tree,
+        };
+    }
+    return resolver_files;
 }
 
 fn collectPublicRootDecls(
@@ -431,74 +448,6 @@ fn isPubToken(tree: *const std.zig.Ast, token: ?std.zig.Ast.TokenIndex) bool {
     return tree.tokenTag(tok) == .keyword_pub;
 }
 
-fn filePubliclyImportsPath(files: []const FileInfo, file: *const FileInfo, target_path: []const u8) bool {
-    const tags = file.tree.nodes.items(.tag);
-
-    for (file.tree.rootDecls()) |decl_idx| {
-        const idx = @intFromEnum(decl_idx);
-        if (idx >= tags.len) continue;
-        if (!isVarDeclTag(tags[idx])) continue;
-        if (publicVarDeclImportsPath(&file.tree, @intCast(idx), file.path, target_path)) return true;
-    }
-    return publicUsingnamespaceImportsPath(files, &file.tree, file.path, target_path);
-}
-
-fn publicVarDeclImportsPath(
-    tree: *const std.zig.Ast,
-    node_idx: u32,
-    importer_path: []const u8,
-    target_path: []const u8,
-) bool {
-    const full = tree.fullVarDecl(@enumFromInt(node_idx)) orelse return false;
-    if (!isPubToken(tree, full.visib_token)) return false;
-
-    const init_node = full.ast.init_node.unwrap() orelse return false;
-    const init_idx = @intFromEnum(init_node);
-    const tags = tree.nodes.items(.tag);
-    if (init_idx >= tags.len) return false;
-
-    switch (tags[init_idx]) {
-        .builtin_call,
-        .builtin_call_comma,
-        .builtin_call_two,
-        .builtin_call_two_comma,
-        => {
-            const import_path = importPathFromBuiltinCall(tree, init_idx) orelse return false;
-            return importMayResolveToPath(importer_path, import_path, target_path);
-        },
-        else => return false,
-    }
-}
-
-fn isVarDeclTag(tag: std.zig.Ast.Node.Tag) bool {
-    return switch (tag) {
-        .simple_var_decl,
-        .aligned_var_decl,
-        .global_var_decl,
-        .local_var_decl,
-        => true,
-        else => false,
-    };
-}
-
-fn isBuiltinCallTag(tag: std.zig.Ast.Node.Tag) bool {
-    return switch (tag) {
-        .builtin_call,
-        .builtin_call_comma,
-        .builtin_call_two,
-        .builtin_call_two_comma,
-        => true,
-        else => false,
-    };
-}
-
-fn isRootDeclNode(tree: *const std.zig.Ast, node_index: usize) bool {
-    for (tree.rootDecls()) |decl| {
-        if (@intFromEnum(decl) == node_index) return true;
-    }
-    return false;
-}
-
 fn isPublicAliasDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) bool {
     if (tree.tokenTag(full.ast.mut_token) != .keyword_const) return false;
 
@@ -527,36 +476,6 @@ fn isImportBuiltinCall(tree: *const std.zig.Ast, node_idx: usize) bool {
     return importPathFromBuiltinCall(tree, node_idx) != null;
 }
 
-fn importPathFromBuiltinCall(tree: *const std.zig.Ast, node_idx: usize) ?[]const u8 {
-    const main_tokens = tree.nodes.items(.main_token);
-    if (node_idx >= main_tokens.len) return null;
-    const token = main_tokens[node_idx];
-    if (token >= tree.tokens.len) return null;
-    if (!std.mem.eql(u8, tree.tokenSlice(token), "@import")) return null;
-
-    const token_tags = tree.tokens.items(.tag);
-    var scan_token = token + 1;
-    const end_token = @min(token_tags.len, token + 6);
-    while (scan_token < end_token) : (scan_token += 1) {
-        if (token_tags[scan_token] != .string_literal) continue;
-        const literal = tree.tokenSlice(scan_token);
-        if (literal.len < 2) return null;
-        return literal[1 .. literal.len - 1];
-    }
-    return null;
-}
-
-fn importResolvesToPath(importer_path: []const u8, import_path: []const u8, target_path: []const u8) bool {
-    if (std.mem.eql(u8, import_path, target_path)) return true;
-
-    const importer_dir = std.fs.path.dirname(importer_path) orelse "";
-    if (importer_dir.len == 0) return pathsEquivalent(import_path, target_path);
-
-    var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const resolved = std.fmt.bufPrint(&resolved_buf, "{s}/{s}", .{ importer_dir, import_path }) catch return false;
-    return pathsEquivalent(resolved, target_path);
-}
-
 fn classifyVarDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) DeclKind {
     if (full.ast.init_node.unwrap()) |init_node| {
         const tag = tree.nodes.items(.tag)[@intFromEnum(init_node)];
@@ -571,13 +490,14 @@ fn classifyVarDecl(tree: *const std.zig.Ast, full: std.zig.Ast.full.VarDecl) Dec
 fn collectProjectUsedDecls(
     allocator: std.mem.Allocator,
     files: []const FileInfo,
+    resolver_files: []const import_resolver.File,
     decls: []const DeclInfo,
 ) ![]bool {
     const used = try allocator.alloc(bool, decls.len);
     @memset(used, false);
 
     for (decls, 0..) |decl, decl_index| {
-        if (isReferencedWithinDeclFile(files, decl) or isReferencedFromAnotherFile(files, decl)) {
+        if (isReferencedWithinDeclFile(files, resolver_files, decl) or isReferencedFromAnotherFile(files, resolver_files, decl)) {
             used[decl_index] = true;
         }
     }
@@ -594,7 +514,7 @@ fn collectProjectUsedDecls(
     return used;
 }
 
-fn isReferencedWithinDeclFile(files: []const FileInfo, decl: DeclInfo) bool {
+fn isReferencedWithinDeclFile(files: []const FileInfo, resolver_files: []const import_resolver.File, decl: DeclInfo) bool {
     const file = files[decl.file_index];
     const tags = file.tree.nodes.items(.tag);
     const main_tokens = file.tree.nodes.items(.main_token);
@@ -608,17 +528,17 @@ fn isReferencedWithinDeclFile(files: []const FileInfo, decl: DeclInfo) bool {
         if (std.mem.eql(u8, name, decl.normalized_name)) return true;
     }
 
-    if (fileReferencesDeclByTypedReceiver(files, decl.file_index, decl.file_index, decl.normalized_name)) return true;
+    if (fileReferencesDeclByTypedReceiver(resolver_files, decl.file_index, decl.file_index, decl.normalized_name)) return true;
 
     return false;
 }
 
-fn isReferencedFromAnotherFile(files: []const FileInfo, decl: DeclInfo) bool {
+fn isReferencedFromAnotherFile(files: []const FileInfo, resolver_files: []const import_resolver.File, decl: DeclInfo) bool {
     const decl_file = files[decl.file_index];
     for (files, 0..) |*file, file_index| {
         if (file_index == decl.file_index) continue;
         if (std.mem.eql(u8, file.path, decl_file.path)) continue;
-        if (fileReferencesDecl(files, file_index, decl.file_index, decl_file.path, decl.normalized_name)) return true;
+        if (fileReferencesDecl(resolver_files, file_index, decl.file_index, decl_file.path, decl.normalized_name)) return true;
     }
     return false;
 }
@@ -827,21 +747,21 @@ const PublicSurfaceScanner = struct {
 };
 
 fn fileReferencesDecl(
-    files: []const FileInfo,
+    files: []const import_resolver.File,
     file_index: usize,
     decl_file_index: usize,
     decl_path: []const u8,
     normalized_name: []const u8,
 ) bool {
-    const file = &files[file_index];
-    if (fileReferencesDeclByFieldAccess(files, &file.tree, file.path, decl_path, normalized_name)) return true;
+    const file = files[file_index];
+    if (fileReferencesDeclByFieldAccess(files, file.tree, file.path, decl_path, normalized_name)) return true;
     if (fileReferencesDeclByTypedReceiver(files, file_index, decl_file_index, normalized_name)) return true;
-    if (fileUsingnamespaceImportsPath(files, &file.tree, file.path, decl_path) and fileReferencesBareName(&file.tree, normalized_name)) return true;
+    if (import_resolver.fileUsingnamespaceImportsPath(files, file.tree, file.path, decl_path) and fileReferencesBareName(file.tree, normalized_name)) return true;
     return false;
 }
 
 fn fileReferencesDeclByFieldAccess(
-    files: []const FileInfo,
+    files: []const import_resolver.File,
     tree: *const std.zig.Ast,
     importer_path: []const u8,
     decl_path: []const u8,
@@ -857,23 +777,23 @@ fn fileReferencesDeclByFieldAccess(
         if (!std.mem.eql(u8, slice, normalized_name)) continue;
 
         const lhs = @intFromEnum(datas[node_index].node_and_token[0]);
-        if (nodeImportsPath(files, tree, lhs, importer_path, decl_path)) return true;
+        if (import_resolver.nodeImportsPath(files, tree, lhs, importer_path, decl_path)) return true;
     }
     return false;
 }
 
 fn fileReferencesDeclByTypedReceiver(
-    files: []const FileInfo,
+    files: []const import_resolver.File,
     file_index: usize,
     decl_file_index: usize,
     normalized_name: []const u8,
 ) bool {
-    const file = &files[file_index];
-    const tree = &file.tree;
+    const file = files[file_index];
+    const tree = file.tree;
     const tags = tree.nodes.items(.tag);
     const datas = tree.nodes.items(.data);
 
-    var resolver = TypeResolver{
+    const resolver = call_resolver.ProjectTypeResolver{
         .files = files,
         .file_index = file_index,
     };
@@ -905,471 +825,6 @@ fn fileReferencesDeclByTypedReceiver(
     return false;
 }
 
-const TypeResolver = struct {
-    files: []const FileInfo,
-    file_index: usize,
-
-    fn currentFile(self: TypeResolver) *const FileInfo {
-        return &self.files[self.file_index];
-    }
-
-    fn resolveExprType(self: TypeResolver, node: usize) ?ResolvedType {
-        const tree = &self.currentFile().tree;
-        const tags = tree.nodes.items(.tag);
-        if (node >= tags.len) return null;
-
-        switch (tags[node]) {
-            .identifier => {
-                const name = identifierName(tree, node) orelse return null;
-                return self.resolveNameType(name, node);
-            },
-            .field_access => {
-                const datas = tree.nodes.items(.data);
-                const field_access = datas[node].node_and_token;
-                const lhs = @intFromEnum(field_access[0]);
-                const member_name = normalizeIdentifier(tree.tokenSlice(field_access[1]));
-                const base_type = self.resolveExprType(lhs) orelse return null;
-                return self.resolveMemberType(base_type, member_name);
-            },
-            .call,
-            .call_comma,
-            .call_one,
-            .call_one_comma,
-            => return self.resolveCallType(@intCast(node)),
-            .struct_init,
-            .struct_init_comma,
-            .struct_init_one,
-            .struct_init_one_comma,
-            .struct_init_dot,
-            .struct_init_dot_comma,
-            .struct_init_dot_two,
-            .struct_init_dot_two_comma,
-            => return self.resolveStructInitType(@intCast(node)),
-            .builtin_call,
-            .builtin_call_comma,
-            .builtin_call_two,
-            .builtin_call_two_comma,
-            => return self.resolveBuiltinType(@intCast(node)),
-            else => return null,
-        }
-    }
-
-    fn resolveTypeNode(self: TypeResolver, node: usize) ?ResolvedType {
-        const tree = &self.currentFile().tree;
-        const tags = tree.nodes.items(.tag);
-        if (node >= tags.len) return null;
-
-        switch (tags[node]) {
-            .identifier => {
-                const name = identifierName(tree, node) orelse return null;
-                return self.resolveNameType(name, node);
-            },
-            .field_access => {
-                const datas = tree.nodes.items(.data);
-                const field_access = datas[node].node_and_token;
-                const lhs = @intFromEnum(field_access[0]);
-                const member_name = normalizeIdentifier(tree.tokenSlice(field_access[1]));
-                const base_type = self.resolveTypeNode(lhs) orelse self.resolveExprType(lhs) orelse return null;
-                return self.resolveMemberType(base_type, member_name);
-            },
-            .ptr_type,
-            .ptr_type_aligned,
-            .ptr_type_bit_range,
-            .ptr_type_sentinel,
-            => {
-                const ptr = tree.fullPtrType(@enumFromInt(node)) orelse return null;
-                return self.resolveTypeNode(@intFromEnum(ptr.ast.child_type));
-            },
-            .optional_type => return self.resolveTypeNode(@intFromEnum(tree.nodes.items(.data)[node].node)),
-            .error_union => return self.resolveTypeNode(@intFromEnum(tree.nodes.items(.data)[node].node_and_node[1])),
-            .builtin_call,
-            .builtin_call_comma,
-            .builtin_call_two,
-            .builtin_call_two_comma,
-            => return self.resolveBuiltinType(@intCast(node)),
-            else => return null,
-        }
-    }
-
-    fn resolveNameType(self: TypeResolver, name: []const u8, reference_node: usize) ?ResolvedType {
-        if (self.resolveNearestBindingType(name, reference_node)) |resolved| return resolved;
-        if (self.resolveNamedDeclType(self.file_index, name)) |resolved| return resolved;
-        if (std.mem.eql(u8, name, fileStem(self.currentFile().path))) {
-            return .{ .file_index = self.file_index };
-        }
-        return null;
-    }
-
-    fn resolveNearestBindingType(self: TypeResolver, name: []const u8, reference_node: usize) ?ResolvedType {
-        const tree = &self.currentFile().tree;
-        const tags = tree.nodes.items(.tag);
-        const reference_start = nodeStart(tree, reference_node) orelse return null;
-
-        var best_start: usize = 0;
-        var best_type: ?ResolvedType = null;
-
-        for (tags, 0..) |tag, node_index| {
-            switch (tag) {
-                .simple_var_decl,
-                .aligned_var_decl,
-                .global_var_decl,
-                .local_var_decl,
-                => {
-                    const full = tree.fullVarDecl(@enumFromInt(node_index)) orelse continue;
-                    const name_token = full.ast.mut_token + 1;
-                    if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
-                    const decl_name = normalizeIdentifier(tree.tokenSlice(name_token));
-                    if (!std.mem.eql(u8, decl_name, name)) continue;
-
-                    const start = tree.tokens.items(.start)[name_token];
-                    if (start > reference_start or start < best_start) continue;
-                    if (self.resolveVarDeclType(full, node_index, decl_name)) |resolved| {
-                        best_start = start;
-                        best_type = resolved;
-                    }
-                },
-                .fn_decl,
-                .fn_proto,
-                .fn_proto_simple,
-                .fn_proto_one,
-                .fn_proto_multi,
-                => {
-                    if (self.resolveFnParamBindingType(@intCast(node_index), name, reference_start, &best_start)) |resolved| {
-                        best_type = resolved;
-                    }
-                },
-                else => {},
-            }
-        }
-
-        return best_type;
-    }
-
-    fn resolveFnParamBindingType(
-        self: TypeResolver,
-        node: u32,
-        name: []const u8,
-        reference_start: usize,
-        best_start: *usize,
-    ) ?ResolvedType {
-        const tree = &self.currentFile().tree;
-        const tags = tree.nodes.items(.tag);
-        if (node >= tags.len) return null;
-
-        if (tags[node] == .fn_decl) {
-            const proto_node = @intFromEnum(tree.nodes.items(.data)[node].node_and_node[0]);
-            return self.resolveFnParamBindingType(@intCast(proto_node), name, reference_start, best_start);
-        }
-
-        var buffer: [1]std.zig.Ast.Node.Index = undefined;
-        const proto = switch (tags[node]) {
-            .fn_proto => tree.fnProto(@enumFromInt(node)),
-            .fn_proto_simple => tree.fnProtoSimple(&buffer, @enumFromInt(node)),
-            .fn_proto_one => tree.fnProtoOne(&buffer, @enumFromInt(node)),
-            .fn_proto_multi => tree.fnProtoMulti(@enumFromInt(node)),
-            else => return null,
-        };
-
-        var best_type: ?ResolvedType = null;
-        for (proto.ast.params) |param_node| {
-            const param_index = @intFromEnum(param_node);
-            if (param_index >= tags.len) continue;
-
-            if (isVarDeclTag(tags[param_index])) {
-                const full = tree.fullVarDecl(param_node) orelse continue;
-                const name_token = full.ast.mut_token + 1;
-                if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
-                const param_name = normalizeIdentifier(tree.tokenSlice(name_token));
-                if (!std.mem.eql(u8, param_name, name)) continue;
-
-                const start = tree.tokens.items(.start)[name_token];
-                if (start > reference_start or start < best_start.*) continue;
-                if (self.resolveVarDeclType(full, param_index, param_name)) |resolved| {
-                    best_start.* = start;
-                    best_type = resolved;
-                }
-                continue;
-            }
-
-            const name_token = paramNameTokenBeforeType(tree, param_index) orelse continue;
-            const param_name = normalizeIdentifier(tree.tokenSlice(@intCast(name_token)));
-            if (!std.mem.eql(u8, param_name, name)) continue;
-
-            const start = tree.tokens.items(.start)[name_token];
-            if (start > reference_start or start < best_start.*) continue;
-            if (self.resolveTypeNode(param_index)) |resolved| {
-                best_start.* = start;
-                best_type = resolved;
-            }
-        }
-        return best_type;
-    }
-
-    fn varDeclInitializerReferencesExpectedTypeMethod(
-        self: TypeResolver,
-        full: std.zig.Ast.full.VarDecl,
-        decl_file_index: usize,
-        method_name: []const u8,
-    ) bool {
-        const type_node = full.ast.type_node.unwrap() orelse return false;
-        const expected_type = self.resolveTypeNode(@intFromEnum(type_node)) orelse return false;
-        if (expected_type.file_index != decl_file_index) return false;
-        if (expected_type.type_name != null) return false;
-
-        const init_node = full.ast.init_node.unwrap() orelse return false;
-        return self.initializerReferencesExpectedTypeMethod(@intFromEnum(init_node), method_name);
-    }
-
-    fn resolveVarDeclType(
-        self: TypeResolver,
-        full: std.zig.Ast.full.VarDecl,
-        node_index: usize,
-        decl_name: []const u8,
-    ) ?ResolvedType {
-        if (full.ast.type_node.unwrap()) |type_node| {
-            if (self.resolveTypeNode(@intFromEnum(type_node))) |resolved| return resolved;
-        }
-
-        const init_node = full.ast.init_node.unwrap() orelse return null;
-        const init_index = @intFromEnum(init_node);
-        const tree = &self.currentFile().tree;
-        const tags = tree.nodes.items(.tag);
-        if (init_index >= tags.len) return null;
-        if (isBuiltinCallTag(tags[init_index])) {
-            return self.resolveBuiltinType(@intCast(init_index));
-        }
-        if (isContainerTag(tags[init_index])) {
-            return .{ .file_index = self.file_index, .type_name = decl_name };
-        }
-        if (isRootDeclNode(tree, node_index)) return null;
-        return self.resolveInitializerType(init_index);
-    }
-
-    fn resolveInitializerType(self: TypeResolver, node: usize) ?ResolvedType {
-        const tree = &self.currentFile().tree;
-        const tags = tree.nodes.items(.tag);
-        if (node >= tags.len) return null;
-
-        return switch (tags[node]) {
-            .call, .call_comma, .call_one, .call_one_comma => self.resolveCallType(@intCast(node)),
-            .@"try",
-            .address_of,
-            .deref,
-            .optional_type,
-            => self.resolveInitializerType(@intFromEnum(tree.nodes.items(.data)[node].node)),
-            .grouped_expression,
-            .unwrap_optional,
-            => self.resolveInitializerType(@intFromEnum(tree.nodes.items(.data)[node].node_and_token[0])),
-            .struct_init,
-            .struct_init_comma,
-            .struct_init_one,
-            .struct_init_one_comma,
-            .struct_init_dot,
-            .struct_init_dot_comma,
-            .struct_init_dot_two,
-            .struct_init_dot_two_comma,
-            => self.resolveStructInitType(@intCast(node)),
-            .builtin_call,
-            .builtin_call_comma,
-            .builtin_call_two,
-            .builtin_call_two_comma,
-            => self.resolveBuiltinType(@intCast(node)),
-            else => null,
-        };
-    }
-
-    fn initializerReferencesExpectedTypeMethod(
-        self: TypeResolver,
-        node: usize,
-        method_name: []const u8,
-    ) bool {
-        const tree = &self.currentFile().tree;
-        const tags = tree.nodes.items(.tag);
-        if (node >= tags.len) return false;
-
-        return switch (tags[node]) {
-            .call,
-            .call_comma,
-            .call_one,
-            .call_one_comma,
-            => self.callUsesImplicitResultMethod(@intCast(node), method_name),
-            .@"try",
-            .address_of,
-            .deref,
-            .optional_type,
-            => self.initializerReferencesExpectedTypeMethod(@intFromEnum(tree.nodes.items(.data)[node].node), method_name),
-            .grouped_expression,
-            .unwrap_optional,
-            => self.initializerReferencesExpectedTypeMethod(@intFromEnum(tree.nodes.items(.data)[node].node_and_token[0]), method_name),
-            .@"catch" => self.initializerReferencesExpectedTypeMethod(@intFromEnum(tree.nodes.items(.data)[node].node_and_node[0]), method_name),
-            else => false,
-        };
-    }
-
-    fn callUsesImplicitResultMethod(self: TypeResolver, node: u32, method_name: []const u8) bool {
-        const tree = &self.currentFile().tree;
-        const tags = tree.nodes.items(.tag);
-        if (node >= tags.len) return false;
-
-        var buffer: [1]std.zig.Ast.Node.Index = undefined;
-        const call = tree.fullCall(&buffer, @enumFromInt(node)) orelse return false;
-        const callee = @intFromEnum(call.ast.fn_expr);
-        if (callee >= tags.len or tags[callee] != .enum_literal) return false;
-
-        const token = tree.nodes.items(.main_token)[callee];
-        if (token >= tree.tokens.len) return false;
-        return std.mem.eql(u8, normalizeIdentifier(tree.tokenSlice(token)), method_name);
-    }
-
-    fn resolveCallType(self: TypeResolver, node: u32) ?ResolvedType {
-        const tree = &self.currentFile().tree;
-        const tags = tree.nodes.items(.tag);
-        if (node >= tags.len) return null;
-
-        var buffer: [1]std.zig.Ast.Node.Index = undefined;
-        const call = tree.fullCall(&buffer, @enumFromInt(node)) orelse return null;
-        const callee = @intFromEnum(call.ast.fn_expr);
-        if (callee >= tags.len) return null;
-        if (tags[callee] == .field_access) {
-            const lhs = @intFromEnum(tree.nodes.items(.data)[callee].node_and_token[0]);
-            return self.resolveTypeNode(lhs) orelse self.resolveExprType(lhs);
-        }
-        return null;
-    }
-
-    fn resolveStructInitType(self: TypeResolver, node: u32) ?ResolvedType {
-        const tree = &self.currentFile().tree;
-        var buffer: [2]std.zig.Ast.Node.Index = undefined;
-        const init = tree.fullStructInit(&buffer, @enumFromInt(node)) orelse return null;
-        const type_node = init.ast.type_expr.unwrap() orelse return null;
-        return self.resolveTypeNode(@intFromEnum(type_node));
-    }
-
-    fn resolveBuiltinType(self: TypeResolver, node: u32) ?ResolvedType {
-        const tree = &self.currentFile().tree;
-        if (importPathFromBuiltinCall(tree, node)) |import_path| {
-            if (resolveImportToFileIndex(self.files, self.currentFile().path, import_path)) |file_index| {
-                return .{ .file_index = file_index };
-            }
-        }
-        if (isThisBuiltinCall(tree, node)) {
-            return .{ .file_index = self.file_index };
-        }
-        return null;
-    }
-
-    fn resolveMemberType(self: TypeResolver, base_type: ResolvedType, member_name: []const u8) ?ResolvedType {
-        const member_resolver = TypeResolver{
-            .files = self.files,
-            .file_index = base_type.file_index,
-        };
-        if (member_resolver.resolveNamedDeclType(base_type.file_index, member_name)) |resolved| return resolved;
-        return member_resolver.resolveFieldType(base_type, member_name);
-    }
-
-    fn resolveNamedDeclType(self: TypeResolver, file_index: usize, name: []const u8) ?ResolvedType {
-        const file = &self.files[file_index];
-        const tree = &file.tree;
-        const tags = tree.nodes.items(.tag);
-
-        for (tree.rootDecls()) |decl_idx| {
-            const node_index = @intFromEnum(decl_idx);
-            if (node_index >= tags.len or !isVarDeclTag(tags[node_index])) continue;
-            const full = tree.fullVarDecl(decl_idx) orelse continue;
-            const name_token = full.ast.mut_token + 1;
-            if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
-            const decl_name = normalizeIdentifier(tree.tokenSlice(name_token));
-            if (!std.mem.eql(u8, decl_name, name)) continue;
-
-            const nested_resolver = TypeResolver{ .files = self.files, .file_index = file_index };
-            if (nested_resolver.resolveVarDeclType(full, node_index, decl_name)) |resolved| return resolved;
-        }
-        return null;
-    }
-
-    fn resolveFieldType(self: TypeResolver, base_type: ResolvedType, field_name: []const u8) ?ResolvedType {
-        if (base_type.type_name) |container_name| {
-            if (self.findNamedContainerNode(base_type.file_index, container_name)) |container_node| {
-                return self.resolveContainerFieldType(base_type.file_index, container_node, field_name);
-            }
-        }
-        return self.resolveRootFieldType(base_type.file_index, field_name);
-    }
-
-    fn findNamedContainerNode(self: TypeResolver, file_index: usize, name: []const u8) ?u32 {
-        const file = &self.files[file_index];
-        const tree = &file.tree;
-        const tags = tree.nodes.items(.tag);
-
-        for (tree.rootDecls()) |decl_idx| {
-            const node_index = @intFromEnum(decl_idx);
-            if (node_index >= tags.len or !isVarDeclTag(tags[node_index])) continue;
-            const full = tree.fullVarDecl(decl_idx) orelse continue;
-            const name_token = full.ast.mut_token + 1;
-            if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) continue;
-            if (!std.mem.eql(u8, normalizeIdentifier(tree.tokenSlice(name_token)), name)) continue;
-            const init_node = full.ast.init_node.unwrap() orelse continue;
-            const init_index = @intFromEnum(init_node);
-            if (init_index < tags.len and isContainerTag(tags[init_index])) return @intCast(init_index);
-        }
-        return null;
-    }
-
-    fn resolveRootFieldType(self: TypeResolver, file_index: usize, field_name: []const u8) ?ResolvedType {
-        const file = &self.files[file_index];
-        const tree = &file.tree;
-        const tags = tree.nodes.items(.tag);
-
-        for (tree.rootDecls()) |decl_idx| {
-            const node_index = @intFromEnum(decl_idx);
-            if (node_index >= tags.len) continue;
-            switch (tags[node_index]) {
-                .container_field,
-                .container_field_init,
-                .container_field_align,
-                => if (self.resolveContainerFieldNodeType(file_index, @intCast(node_index), field_name)) |resolved| return resolved,
-                else => {},
-            }
-        }
-        return null;
-    }
-
-    fn resolveContainerFieldType(self: TypeResolver, file_index: usize, container_node: u32, field_name: []const u8) ?ResolvedType {
-        const file = &self.files[file_index];
-        const tree = &file.tree;
-
-        var buffer: [2]std.zig.Ast.Node.Index = undefined;
-        const container = tree.fullContainerDecl(&buffer, @enumFromInt(container_node)) orelse return null;
-        for (container.ast.members) |member_node| {
-            const member = @intFromEnum(member_node);
-            if (self.resolveContainerFieldNodeType(file_index, @intCast(member), field_name)) |resolved| return resolved;
-        }
-        return null;
-    }
-
-    fn resolveContainerFieldNodeType(self: TypeResolver, file_index: usize, node: u32, field_name: []const u8) ?ResolvedType {
-        const file = &self.files[file_index];
-        const tree = &file.tree;
-        const tags = tree.nodes.items(.tag);
-        if (node >= tags.len) return null;
-
-        const field = tree.fullContainerField(@enumFromInt(node)) orelse return null;
-        if (field.ast.tuple_like) return null;
-        const name_token = field.ast.main_token;
-        if (name_token >= tree.tokens.len or tree.tokenTag(name_token) != .identifier) return null;
-        if (!std.mem.eql(u8, normalizeIdentifier(tree.tokenSlice(name_token)), field_name)) return null;
-
-        const nested_resolver = TypeResolver{ .files = self.files, .file_index = file_index };
-        if (field.ast.type_expr.unwrap()) |type_node| {
-            return nested_resolver.resolveTypeNode(@intFromEnum(type_node));
-        }
-        if (field.ast.value_expr.unwrap()) |value_node| {
-            return nested_resolver.resolveInitializerType(@intFromEnum(value_node));
-        }
-        return null;
-    }
-};
-
 fn fileReferencesBareName(tree: *const std.zig.Ast, normalized_name: []const u8) bool {
     const tags = tree.nodes.items(.tag);
     const main_tokens = tree.nodes.items(.main_token);
@@ -1383,297 +838,6 @@ fn fileReferencesBareName(tree: *const std.zig.Ast, normalized_name: []const u8)
     return false;
 }
 
-fn nodeImportsPath(
-    files: []const FileInfo,
-    tree: *const std.zig.Ast,
-    node: usize,
-    importer_path: []const u8,
-    target_path: []const u8,
-) bool {
-    const tags = tree.nodes.items(.tag);
-    if (node >= tags.len) return false;
-
-    switch (tags[node]) {
-        .identifier => {
-            const name = identifierName(tree, node) orelse return false;
-            return importAliasResolvesToPath(tree, importer_path, name, target_path);
-        },
-        .builtin_call,
-        .builtin_call_comma,
-        .builtin_call_two,
-        .builtin_call_two_comma,
-        => {
-            const import_path = importPathFromBuiltinCall(tree, node) orelse return false;
-            return importMayResolveToPath(importer_path, import_path, target_path);
-        },
-        .field_access => {
-            const datas = tree.nodes.items(.data);
-            const lhs = @intFromEnum(datas[node].node_and_token[0]);
-            const field_name = normalizeIdentifier(tree.tokenSlice(datas[node].node_and_token[1]));
-
-            for (files) |*candidate| {
-                if (!nodeImportsPath(files, tree, lhs, importer_path, candidate.path)) continue;
-                if (filePublicMemberImportsPath(candidate, field_name, target_path)) return true;
-            }
-            return false;
-        },
-        else => return false,
-    }
-}
-
-fn importAliasResolvesToPath(
-    tree: *const std.zig.Ast,
-    importer_path: []const u8,
-    alias_name: []const u8,
-    target_path: []const u8,
-) bool {
-    const tags = tree.nodes.items(.tag);
-
-    for (tags, 0..) |tag, node_index| {
-        if (!isVarDeclTag(tag)) continue;
-        const full = tree.fullVarDecl(@enumFromInt(node_index)) orelse continue;
-        const name_token = full.ast.mut_token + 1;
-        if (name_token >= tree.tokens.len) continue;
-        if (tree.tokenTag(name_token) != .identifier) continue;
-
-        const name = normalizeIdentifier(tree.tokenSlice(name_token));
-        if (!std.mem.eql(u8, name, alias_name)) continue;
-
-        const init_node = full.ast.init_node.unwrap() orelse continue;
-        if (initNodeImportsPath(tree, @intFromEnum(init_node), importer_path, target_path)) return true;
-    }
-
-    return false;
-}
-
-fn fileUsingnamespaceImportsPath(
-    files: []const FileInfo,
-    tree: *const std.zig.Ast,
-    importer_path: []const u8,
-    target_path: []const u8,
-) bool {
-    const token_tags = tree.tokens.items(.tag);
-
-    for (token_tags, 0..) |_, token_index| {
-        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(token_index)), "usingnamespace")) continue;
-
-        const import_token = nextNonCommentToken(token_tags, token_index + 1) orelse continue;
-        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(import_token)), "@import")) continue;
-
-        const import_path = importPathFromBuiltinToken(tree, import_token) orelse continue;
-        if (importMayResolveToPath(importer_path, import_path, target_path)) return true;
-        if (resolveImportToFileIndex(files, importer_path, import_path)) |file_index| {
-            if (filePubliclyImportsPath(files, &files[file_index], target_path)) return true;
-        }
-    }
-
-    return false;
-}
-
-fn publicUsingnamespaceImportsPath(
-    files: []const FileInfo,
-    tree: *const std.zig.Ast,
-    importer_path: []const u8,
-    target_path: []const u8,
-) bool {
-    const token_tags = tree.tokens.items(.tag);
-
-    for (token_tags, 0..) |_, token_index| {
-        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(token_index)), "usingnamespace")) continue;
-
-        const pub_token = prevNonCommentToken(token_tags, token_index) orelse continue;
-        if (tree.tokenTag(@intCast(pub_token)) != .keyword_pub) continue;
-
-        const import_token = nextNonCommentToken(token_tags, token_index + 1) orelse continue;
-        if (!std.mem.eql(u8, tree.tokenSlice(@intCast(import_token)), "@import")) continue;
-
-        const import_path = importPathFromBuiltinToken(tree, import_token) orelse continue;
-        if (importMayResolveToPath(importer_path, import_path, target_path)) return true;
-        if (resolveImportToFileIndex(files, importer_path, import_path)) |file_index| {
-            if (filePubliclyImportsPath(files, &files[file_index], target_path)) return true;
-        }
-    }
-
-    return false;
-}
-
-fn importPathFromBuiltinToken(tree: *const std.zig.Ast, token: usize) ?[]const u8 {
-    const token_tags = tree.tokens.items(.tag);
-    const l_paren = nextNonCommentToken(token_tags, token + 1) orelse return null;
-    if (token_tags[l_paren] != .l_paren) return null;
-
-    const string_token = nextNonCommentToken(token_tags, l_paren + 1) orelse return null;
-    if (token_tags[string_token] != .string_literal) return null;
-
-    const literal = tree.tokenSlice(@intCast(string_token));
-    if (literal.len < 2) return null;
-    return literal[1 .. literal.len - 1];
-}
-
-fn initNodeImportsPath(
-    tree: *const std.zig.Ast,
-    node: usize,
-    importer_path: []const u8,
-    target_path: []const u8,
-) bool {
-    const tags = tree.nodes.items(.tag);
-    if (node >= tags.len) return false;
-
-    switch (tags[node]) {
-        .builtin_call,
-        .builtin_call_comma,
-        .builtin_call_two,
-        .builtin_call_two_comma,
-        => {
-            const import_path = importPathFromBuiltinCall(tree, node) orelse return false;
-            return importMayResolveToPath(importer_path, import_path, target_path);
-        },
-        else => {
-            var scanner = ImportPathScanner{
-                .importer_path = importer_path,
-                .target_path = target_path,
-            };
-            ast_walk.walk(ImportPathScanner, tree, @intCast(node), &scanner) catch return false;
-            return scanner.found;
-        },
-    }
-}
-
-const ImportPathScanner = struct {
-    importer_path: []const u8,
-    target_path: []const u8,
-    found: bool = false,
-    stop: bool = false,
-
-    pub fn visit(
-        self: *ImportPathScanner,
-        tree: *const std.zig.Ast,
-        node: u32,
-        tag: std.zig.Ast.Node.Tag,
-    ) anyerror!void {
-        switch (tag) {
-            .builtin_call,
-            .builtin_call_comma,
-            .builtin_call_two,
-            .builtin_call_two_comma,
-            => {
-                const import_path = importPathFromBuiltinCall(tree, node) orelse return;
-                if (importMayResolveToPath(self.importer_path, import_path, self.target_path)) {
-                    self.found = true;
-                    self.stop = true;
-                }
-            },
-            else => {},
-        }
-    }
-};
-
-fn nextNonCommentToken(token_tags: []const std.zig.Token.Tag, start: usize) ?usize {
-    var index = start;
-    while (index < token_tags.len) : (index += 1) {
-        switch (token_tags[index]) {
-            .container_doc_comment, .doc_comment => continue,
-            else => return index,
-        }
-    }
-    return null;
-}
-
-fn prevNonCommentToken(token_tags: []const std.zig.Token.Tag, start: usize) ?usize {
-    if (start == 0) return null;
-    var index = start - 1;
-    while (true) {
-        switch (token_tags[index]) {
-            .container_doc_comment, .doc_comment => {},
-            else => return index,
-        }
-        if (index == 0) return null;
-        index -= 1;
-    }
-}
-
-fn paramNameTokenBeforeType(tree: *const std.zig.Ast, type_node: usize) ?usize {
-    const main_tokens = tree.nodes.items(.main_token);
-    if (type_node >= main_tokens.len) return null;
-    const token_tags = tree.tokens.items(.tag);
-    const type_token = main_tokens[type_node];
-    const colon_token = prevNonCommentToken(token_tags, type_token) orelse return null;
-    if (token_tags[colon_token] != .colon) return null;
-    const name_token = prevNonCommentToken(token_tags, colon_token) orelse return null;
-    if (token_tags[name_token] != .identifier) return null;
-    return name_token;
-}
-
-fn identifierName(tree: *const std.zig.Ast, node: usize) ?[]const u8 {
-    const tags = tree.nodes.items(.tag);
-    if (node >= tags.len or tags[node] != .identifier) return null;
-    const main_tokens = tree.nodes.items(.main_token);
-    if (node >= main_tokens.len) return null;
-    return normalizeIdentifier(tree.tokenSlice(main_tokens[node]));
-}
-
-fn fieldAccessName(tree: *const std.zig.Ast, node: usize) ?[]const u8 {
-    const tags = tree.nodes.items(.tag);
-    if (node >= tags.len or tags[node] != .field_access) return null;
-    const datas = tree.nodes.items(.data);
-    return normalizeIdentifier(tree.tokenSlice(datas[node].node_and_token[1]));
-}
-
-fn filePublicMemberImportsPath(file: *const FileInfo, member_name: []const u8, target_path: []const u8) bool {
-    const tags = file.tree.nodes.items(.tag);
-
-    for (file.tree.rootDecls()) |decl_idx| {
-        const idx = @intFromEnum(decl_idx);
-        if (idx >= tags.len) continue;
-        if (!isVarDeclTag(tags[idx])) continue;
-        if (publicVarDeclNamedImportsPath(&file.tree, @intCast(idx), file.path, member_name, target_path)) return true;
-    }
-    return false;
-}
-
-fn publicVarDeclNamedImportsPath(
-    tree: *const std.zig.Ast,
-    node_idx: u32,
-    importer_path: []const u8,
-    expected_name: []const u8,
-    target_path: []const u8,
-) bool {
-    const full = tree.fullVarDecl(@enumFromInt(node_idx)) orelse return false;
-    if (!isPubToken(tree, full.visib_token)) return false;
-
-    const name_token = full.ast.mut_token + 1;
-    if (name_token >= tree.tokens.len) return false;
-    if (tree.tokenTag(name_token) != .identifier) return false;
-    const name = normalizeIdentifier(tree.tokenSlice(name_token));
-    if (!std.mem.eql(u8, name, expected_name)) return false;
-
-    const init_node = full.ast.init_node.unwrap() orelse return false;
-    const import_path = importPathFromBuiltinCall(tree, @intFromEnum(init_node)) orelse return false;
-    return importMayResolveToPath(importer_path, import_path, target_path);
-}
-
-fn importMayResolveToPath(importer_path: []const u8, import_path: []const u8, target_path: []const u8) bool {
-    if (importResolvesToPath(importer_path, import_path, target_path)) return true;
-    return packageImportMayResolveToPath(import_path, target_path);
-}
-
-fn resolveImportToFileIndex(files: []const FileInfo, importer_path: []const u8, import_path: []const u8) ?usize {
-    for (files, 0..) |file, file_index| {
-        if (importMayResolveToPath(importer_path, import_path, file.path)) return file_index;
-    }
-    return null;
-}
-
-fn packageImportMayResolveToPath(import_path: []const u8, target_path: []const u8) bool {
-    if (std.mem.indexOfScalar(u8, import_path, '/') != null) return false;
-    if (std.mem.endsWith(u8, import_path, ".zig")) return false;
-
-    const basename = std.fs.path.basename(target_path);
-    if (!std.mem.endsWith(u8, basename, ".zig")) return false;
-    const stem = basename[0 .. basename.len - ".zig".len];
-    return std.mem.eql(u8, stem, import_path);
-}
-
 fn isReexportAlias(public_name: []const u8, referenced_name: []const u8) bool {
     const normalized_public = normalizeIdentifier(public_name);
     const normalized_referenced = normalizeIdentifier(referenced_name);
@@ -1684,79 +848,6 @@ fn isReexportAlias(public_name: []const u8, referenced_name: []const u8) bool {
 fn isTypeLikeName(name: []const u8) bool {
     if (name.len == 0) return false;
     return std.ascii.isUpper(name[0]);
-}
-
-fn pathsEquivalent(a: []const u8, b: []const u8) bool {
-    var a_buf: [std.fs.max_path_bytes]u8 = undefined;
-    var b_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const normalized_a = normalizePath(&a_buf, a) catch return false;
-    const normalized_b = normalizePath(&b_buf, b) catch return false;
-    return std.mem.eql(u8, normalized_a, normalized_b);
-}
-
-fn normalizePath(buffer: []u8, path: []const u8) ![]const u8 {
-    var segments: [128][]const u8 = undefined;
-    var segment_count: usize = 0;
-
-    var rest = path;
-    while (rest.len > 0) {
-        const slash_index = std.mem.indexOfScalar(u8, rest, '/') orelse rest.len;
-        const segment = rest[0..slash_index];
-        if (segment.len != 0 and !std.mem.eql(u8, segment, ".")) {
-            if (std.mem.eql(u8, segment, "..") and segment_count > 0) {
-                segment_count -= 1;
-            } else {
-                if (segment_count >= segments.len) return error.PathTooManySegments;
-                segments[segment_count] = segment;
-                segment_count += 1;
-            }
-        }
-        if (slash_index == rest.len) break;
-        rest = rest[slash_index + 1 ..];
-    }
-
-    var len: usize = 0;
-    for (segments[0..segment_count]) |segment| {
-        if (len != 0) {
-            if (len >= buffer.len) return error.PathTooLong;
-            buffer[len] = '/';
-            len += 1;
-        }
-        if (len + segment.len > buffer.len) return error.PathTooLong;
-        @memcpy(buffer[len..][0..segment.len], segment);
-        len += segment.len;
-    }
-
-    return buffer[0..len];
-}
-
-fn normalizeIdentifier(ident: []const u8) []const u8 {
-    if (ident.len >= 3 and std.mem.startsWith(u8, ident, "@\"") and ident[ident.len - 1] == '"') {
-        return ident[2 .. ident.len - 1];
-    }
-    return ident;
-}
-
-fn nodeStart(tree: *const std.zig.Ast, node: usize) ?usize {
-    const main_tokens = tree.nodes.items(.main_token);
-    if (node >= main_tokens.len) return null;
-    const token = main_tokens[node];
-    if (token >= tree.tokens.len) return null;
-    return tree.tokens.items(.start)[token];
-}
-
-fn isThisBuiltinCall(tree: *const std.zig.Ast, node: usize) bool {
-    const main_tokens = tree.nodes.items(.main_token);
-    if (node >= main_tokens.len) return false;
-    const token = main_tokens[node];
-    if (token >= tree.tokens.len) return false;
-    return std.mem.eql(u8, tree.tokenSlice(token), "@This");
-}
-
-fn fileStem(path: []const u8) []const u8 {
-    const basename = std.fs.path.basename(path);
-    if (std.mem.endsWith(u8, basename, ".zig")) return basename[0 .. basename.len - ".zig".len];
-    return basename;
 }
 
 fn isIgnoredPublicDecl(path: []const u8, name: []const u8) bool {

--- a/src/rules/deinit_lifecycle.zig
+++ b/src/rules/deinit_lifecycle.zig
@@ -237,13 +237,11 @@ pub const DeinitLifecycleRule = struct {
             const method_token = field_access[1];
 
             if (method_token >= token_tags.len or token_tags[method_token] != .identifier) return null;
-            if (receiver_node == 0 or receiver_node >= self.tags.len or self.tags[receiver_node] != .identifier) return null;
-
-            const receiver_token = self.tree.nodes.items(.main_token)[receiver_node];
-            if (receiver_token >= token_tags.len or token_tags[receiver_token] != .identifier) return null;
+            if (receiver_node == 0 or receiver_node >= self.tags.len) return null;
+            const receiver = call_utils.receiverSourceSlice(self.src.getContent(), self.tree, receiver_node) orelse return null;
 
             return .{
-                .receiver = self.tree.tokenSlice(receiver_token),
+                .receiver = receiver,
                 .method = self.tree.tokenSlice(method_token),
             };
         }
@@ -313,12 +311,10 @@ pub const DeinitLifecycleRule = struct {
             const pair = self.datas[stmt].node_and_node;
             const lhs = @intFromEnum(pair[0]);
             const rhs = @intFromEnum(pair[1]);
-            if (lhs == 0 or lhs >= self.tags.len or self.tags[lhs] != .identifier) return null;
+            if (lhs == 0 or lhs >= self.tags.len) return null;
 
-            const token_tags = self.tree.tokens.items(.tag);
-            const lhs_token = self.tree.nodes.items(.main_token)[lhs];
-            if (lhs_token >= token_tags.len or token_tags[lhs_token] != .identifier) return null;
-            if (!std.mem.eql(u8, self.tree.tokenSlice(lhs_token), receiver)) return null;
+            const lhs_receiver = call_utils.receiverSourceSlice(self.src.getContent(), self.tree, lhs) orelse return null;
+            if (!std.mem.eql(u8, lhs_receiver, receiver)) return null;
 
             if (rhs == 0 or rhs >= self.tags.len) return false;
             return self.tags[rhs] == .@"try";

--- a/src/rules/deinit_lifecycle.zig
+++ b/src/rules/deinit_lifecycle.zig
@@ -53,12 +53,16 @@ pub const DeinitLifecycleRule = struct {
         const tags = tree.nodes.items(.tag);
         const datas = tree.nodes.items(.data);
 
+        var receiver_arena = std.heap.ArenaAllocator.init(allocator);
+        defer receiver_arena.deinit();
+
         var scanner = Scanner{
             .src = src,
             .tree = tree,
             .tags = tags,
             .datas = datas,
             .allocator = allocator,
+            .receiver_allocator = receiver_arena.allocator(),
             .diagnostics = diagnostics,
             .active_cleanup_receivers = .empty,
         };
@@ -89,6 +93,7 @@ pub const DeinitLifecycleRule = struct {
         tags: []const Ast.Node.Tag,
         datas: []const Ast.Node.Data,
         allocator: std.mem.Allocator,
+        receiver_allocator: std.mem.Allocator,
         diagnostics: *std.ArrayList(Diagnostic),
         active_cleanup_receivers: std.ArrayList(ActiveCleanup),
 
@@ -124,7 +129,7 @@ pub const DeinitLifecycleRule = struct {
                     else => continue,
                 };
 
-                if (self.extractDeferredMethodCall(stmt)) |call| {
+                if (try self.extractDeferredMethodCall(stmt)) |call| {
                     if (!isCleanupMethod(call.method)) continue;
                     try self.recordDeferredCleanup(
                         &deferred_cleanups,
@@ -144,7 +149,7 @@ pub const DeinitLifecycleRule = struct {
             for (statements, 0..) |stmt, idx| {
                 switch (self.tags[stmt]) {
                     .@"defer", .@"errdefer" => {
-                        if (self.extractDeferredMethodCall(stmt)) |call| {
+                        if (try self.extractDeferredMethodCall(stmt)) |call| {
                             if (isCleanupMethod(call.method) and !self.hasActiveCleanup(call.receiver, call.method)) {
                                 try self.active_cleanup_receivers.append(self.allocator, .{
                                     .receiver = call.receiver,
@@ -156,9 +161,9 @@ pub const DeinitLifecycleRule = struct {
                     else => {},
                 }
 
-                if (self.extractDirectCleanupCall(stmt)) |call| {
+                if (try self.extractDirectCleanupCall(stmt)) |call| {
                     if (self.hasActiveCleanup(call.receiver, call.method) and
-                        self.findTryReinit(statements[idx + 1 ..], call.receiver) != null)
+                        (try self.findTryReinit(statements[idx + 1 ..], call.receiver)) != null)
                     {
                         try self.emitCleanupBeforeTryReinit(stmt, call.receiver, call.method);
                     }
@@ -193,7 +198,7 @@ pub const DeinitLifecycleRule = struct {
             }
         }
 
-        fn extractDeferredMethodCall(self: *const Scanner, stmt: u32) ?MethodCall {
+        fn extractDeferredMethodCall(self: *const Scanner, stmt: u32) RuleError!?MethodCall {
             const body: u32 = switch (self.tags[stmt]) {
                 .@"defer" => @intFromEnum(self.datas[stmt].node),
                 .@"errdefer" => @intFromEnum(self.datas[stmt].opt_token_and_node[1]),
@@ -201,7 +206,7 @@ pub const DeinitLifecycleRule = struct {
             };
             if (body == 0 or body >= self.tags.len) return null;
 
-            if (self.extractMethodCall(body)) |call| return call;
+            if (try self.extractMethodCall(body)) |call| return call;
 
             if (self.tags[body] == .block or self.tags[body] == .block_semicolon or
                 self.tags[body] == .block_two or self.tags[body] == .block_two_semicolon)
@@ -209,20 +214,20 @@ pub const DeinitLifecycleRule = struct {
                 var scratch: [2]u32 = undefined;
                 const statements = self.blockStatements(body, &scratch);
                 if (statements.len == 1) {
-                    return self.extractMethodCall(statements[0]);
+                    return try self.extractMethodCall(statements[0]);
                 }
             }
 
             return null;
         }
 
-        fn extractDirectCleanupCall(self: *const Scanner, stmt: u32) ?MethodCall {
-            const call = self.extractMethodCall(stmt) orelse return null;
+        fn extractDirectCleanupCall(self: *const Scanner, stmt: u32) RuleError!?MethodCall {
+            const call = (try self.extractMethodCall(stmt)) orelse return null;
             if (!isCleanupMethod(call.method)) return null;
             return call;
         }
 
-        fn extractMethodCall(self: *const Scanner, expr_node: u32) ?MethodCall {
+        fn extractMethodCall(self: *const Scanner, expr_node: u32) RuleError!?MethodCall {
             if (expr_node >= self.tags.len) return null;
             if (!call_utils.isCallNode(self.tags[expr_node])) return null;
 
@@ -238,12 +243,56 @@ pub const DeinitLifecycleRule = struct {
 
             if (method_token >= token_tags.len or token_tags[method_token] != .identifier) return null;
             if (receiver_node == 0 or receiver_node >= self.tags.len) return null;
-            const receiver = call_utils.receiverSourceSlice(self.src.getContent(), self.tree, receiver_node) orelse return null;
+            const receiver = (try self.canonicalReceiver(receiver_node)) orelse return null;
 
             return .{
                 .receiver = receiver,
                 .method = self.tree.tokenSlice(method_token),
             };
+        }
+
+        fn canonicalReceiver(self: *const Scanner, receiver_node: u32) RuleError!?[]const u8 {
+            const token_tags = self.tree.tokens.items(.tag);
+            const main_tokens = self.tree.nodes.items(.main_token);
+
+            var parts: [32][]const u8 = undefined;
+            var part_count: usize = 0;
+            var node = receiver_node;
+
+            while (true) {
+                if (node == 0 or node >= self.tags.len) return null;
+                switch (self.tags[node]) {
+                    .identifier => {
+                        const token = main_tokens[node];
+                        if (token >= token_tags.len or token_tags[token] != .identifier) return null;
+                        if (part_count >= parts.len) return null;
+                        parts[part_count] = self.tree.tokenSlice(token);
+                        part_count += 1;
+                        break;
+                    },
+                    .field_access => {
+                        const field_access = self.datas[node].node_and_token;
+                        const field_token = field_access[1];
+                        if (field_token >= token_tags.len or token_tags[field_token] != .identifier) return null;
+                        if (part_count >= parts.len) return null;
+                        parts[part_count] = self.tree.tokenSlice(field_token);
+                        part_count += 1;
+                        node = @intFromEnum(field_access[0]);
+                    },
+                    else => return null,
+                }
+            }
+
+            var canonical: std.ArrayList(u8) = .empty;
+            errdefer canonical.deinit(self.receiver_allocator);
+
+            var idx = part_count;
+            while (idx > 0) : (idx -= 1) {
+                if (canonical.items.len > 0) try canonical.append(self.receiver_allocator, '.');
+                try canonical.appendSlice(self.receiver_allocator, parts[idx - 1]);
+            }
+
+            return try canonical.toOwnedSlice(self.receiver_allocator);
         }
 
         fn recordDeferredCleanup(
@@ -296,16 +345,16 @@ pub const DeinitLifecycleRule = struct {
             return false;
         }
 
-        fn findTryReinit(self: *const Scanner, statements: []const u32, receiver: []const u8) ?u32 {
+        fn findTryReinit(self: *const Scanner, statements: []const u32, receiver: []const u8) RuleError!?u32 {
             for (statements) |stmt| {
-                if (self.assignmentToReceiverIsTry(stmt, receiver)) |is_try| {
+                if (try self.assignmentToReceiverIsTry(stmt, receiver)) |is_try| {
                     return if (is_try) stmt else null;
                 }
             }
             return null;
         }
 
-        fn assignmentToReceiverIsTry(self: *const Scanner, stmt: u32, receiver: []const u8) ?bool {
+        fn assignmentToReceiverIsTry(self: *const Scanner, stmt: u32, receiver: []const u8) RuleError!?bool {
             if (stmt >= self.tags.len or !isAssignTag(self.tags[stmt])) return null;
 
             const pair = self.datas[stmt].node_and_node;
@@ -313,7 +362,7 @@ pub const DeinitLifecycleRule = struct {
             const rhs = @intFromEnum(pair[1]);
             if (lhs == 0 or lhs >= self.tags.len) return null;
 
-            const lhs_receiver = call_utils.receiverSourceSlice(self.src.getContent(), self.tree, lhs) orelse return null;
+            const lhs_receiver = (try self.canonicalReceiver(lhs)) orelse return null;
             if (!std.mem.eql(u8, lhs_receiver, receiver)) return null;
 
             if (rhs == 0 or rhs >= self.tags.len) return false;

--- a/src/rules/sentinel_alloc.zig
+++ b/src/rules/sentinel_alloc.zig
@@ -214,6 +214,10 @@ pub const SentinelAllocRule = struct {
         bridge: ?*const ZirBridge,
         call_node: u32,
     ) ?TypeInfo {
+        if (call_utils.resolveResultLocationType(tree, type_ctx, parent_map, call_node)) |ti| {
+            if (!isUnknownTypeInfo(ti)) return ti;
+        }
+
         var node = call_node;
         var depth: u32 = 0;
         while (node < parent_map.len and depth < 64) : (depth += 1) {

--- a/src/type_context.zig
+++ b/src/type_context.zig
@@ -336,7 +336,7 @@ pub const TypeContext = struct {
                     const name = tree.tokenSlice(name_token);
                     if (!std.mem.eql(u8, name, field_name)) continue;
                     if (field.ast.type_expr.unwrap()) |type_node| {
-                        return self.getTypeFromAstNode(tree, @intFromEnum(type_node));
+                        return self.getTypeFromAstNode(@intFromEnum(type_node));
                     }
                     if (field.ast.value_expr.unwrap()) |value_node| {
                         return self.getExpressionTypeInternal(@intFromEnum(value_node), use_known_methods, use_cache);
@@ -350,7 +350,7 @@ pub const TypeContext = struct {
                     const name = tree.tokenSlice(name_token);
                     if (!std.mem.eql(u8, name, field_name)) continue;
                     if (field.ast.type_expr.unwrap()) |type_node| {
-                        return self.getTypeFromAstNode(tree, @intFromEnum(type_node));
+                        return self.getTypeFromAstNode(@intFromEnum(type_node));
                     }
                     if (field.ast.value_expr.unwrap()) |value_node| {
                         return self.getExpressionTypeInternal(@intFromEnum(value_node), use_known_methods, use_cache);
@@ -364,7 +364,7 @@ pub const TypeContext = struct {
                     const name = tree.tokenSlice(name_token);
                     if (!std.mem.eql(u8, name, field_name)) continue;
                     if (field.ast.type_expr.unwrap()) |type_node| {
-                        return self.getTypeFromAstNode(tree, @intFromEnum(type_node));
+                        return self.getTypeFromAstNode(@intFromEnum(type_node));
                     }
                     if (field.ast.value_expr.unwrap()) |value_node| {
                         return self.getExpressionTypeInternal(@intFromEnum(value_node), use_known_methods, use_cache);
@@ -551,7 +551,7 @@ pub const TypeContext = struct {
                         }
                     }
 
-                    if (self.getTypeFromAstNode(tree, type_node)) |ti| {
+                    if (self.getTypeFromAstNode(type_node)) |ti| {
                         if (ti.kind != .unknown or ti.type_str != null) {
                             return ti;
                         }
@@ -607,8 +607,7 @@ pub const TypeContext = struct {
             std.mem.indexOf(u8, name, "error") != null;
     }
 
-    fn getTypeFromAstNode(self: *TypeContext, tree: *const std.zig.Ast, ast_node: u32) ?TypeInfo {
-        _ = tree;
+    pub fn getTypeFromAstNode(self: *TypeContext, ast_node: u32) ?TypeInfo {
         const bridge = self.source.zirBridge() orelse return null;
         return bridge.getTypeFromAstNode(ast_node);
     }
@@ -631,7 +630,7 @@ pub const TypeContext = struct {
                 var buf: [2]std.zig.Ast.Node.Index = undefined;
                 const struct_init = tree.fullStructInit(&buf, @enumFromInt(init_node)) orelse return null;
                 if (struct_init.ast.type_expr.unwrap()) |type_node| {
-                    if (self.getTypeFromAstNode(tree, @intFromEnum(type_node))) |ti| {
+                    if (self.getTypeFromAstNode(@intFromEnum(type_node))) |ti| {
                         if (ti.kind != .unknown or ti.type_str != null) return ti;
                     }
                 }
@@ -648,7 +647,7 @@ pub const TypeContext = struct {
                 var buf: [2]std.zig.Ast.Node.Index = undefined;
                 const array_init = tree.fullArrayInit(&buf, @enumFromInt(init_node)) orelse return null;
                 if (array_init.ast.type_expr.unwrap()) |type_node| {
-                    if (self.getTypeFromAstNode(tree, @intFromEnum(type_node))) |ti| {
+                    if (self.getTypeFromAstNode(@intFromEnum(type_node))) |ti| {
                         if (ti.kind != .unknown or ti.type_str != null) return ti;
                     }
                 }

--- a/test/fixtures/deinit_lifecycle/detects_chained_receiver_cleanup_before_try_reinit.zig
+++ b/test/fixtures/deinit_lifecycle/detects_chained_receiver_cleanup_before_try_reinit.zig
@@ -1,0 +1,19 @@
+// EXPECT: rule=deinit-lifecycle severity=hint message=fallible reinitialization
+const Obj = struct {
+    fn deinit(_: *Obj) void {}
+};
+
+const Holder = struct {
+    value: Obj,
+};
+
+fn makeObj() !Obj {
+    return Obj{};
+}
+
+fn run() !void {
+    var holder = Holder{ .value = Obj{} };
+    defer holder.value.deinit();
+    holder.value.deinit();
+    holder.value = try makeObj();
+}

--- a/test/fixtures/deinit_lifecycle/detects_formatted_chained_receiver_cleanup.zig
+++ b/test/fixtures/deinit_lifecycle/detects_formatted_chained_receiver_cleanup.zig
@@ -1,0 +1,19 @@
+// EXPECT: rule=deinit-lifecycle severity=hint message=fallible reinitialization
+const Obj = struct {
+    fn deinit(_: *Obj) void {}
+};
+
+const Holder = struct {
+    value: Obj,
+};
+
+fn makeObj() !Obj {
+    return Obj{};
+}
+
+fn run() !void {
+    var holder = Holder{ .value = Obj{} };
+    defer holder.value.deinit();
+    holder . value.deinit();
+    holder . value = try makeObj();
+}

--- a/test/fixtures/sentinel_alloc/allows_result_location_cast_preserves_sentinel.zig
+++ b/test/fixtures/sentinel_alloc/allows_result_location_cast_preserves_sentinel.zig
@@ -1,0 +1,7 @@
+// EXPECT: none
+const std = @import("std");
+
+fn foo(allocator: std.mem.Allocator) void {
+    const content = @as([:0]u8, allocator.dupeZ(u8, "hello") catch return);
+    _ = content;
+}

--- a/test/fixtures/stack_escape_engine/typed_receiver_escape_model.zig
+++ b/test/fixtures/stack_escape_engine/typed_receiver_escape_model.zig
@@ -1,0 +1,13 @@
+// CONFIG: {"escape_models":[{"method_name":"capture","receiver_type":"Sink","param_indices":[0],"captures_into":"receiver"}]}
+// EXPECT: rule=stack-escape-engine severity=error message=Stack
+// zwanzig-disable: unused-decl
+
+const Sink = struct {
+    fn capture(_: *Sink, _: []u8) void {}
+};
+
+fn storesStackSlice() void {
+    var sink = Sink{};
+    var buffer = [_]u8{ 0, 1, 2, 3 };
+    sink.capture(buffer[0..]);
+}

--- a/test/fixtures/store_violations_engine/bare_close_helper_does_not_close_resource.zig
+++ b/test/fixtures/store_violations_engine/bare_close_helper_does_not_close_resource.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+
+fn close(_: std.fs.File) void {}
+
+fn foo() !void {
+    var file = try std.fs.cwd().openFile("foo", .{});
+    close(file);
+}
+
+// EXPECT: rule=store-violations-engine severity=error message=resource leak

--- a/test/fixtures/store_violations_engine/identifier_resource_model.zig
+++ b/test/fixtures/store_violations_engine/identifier_resource_model.zig
@@ -1,0 +1,12 @@
+// CONFIG: {"resource_models":[{"kind":"open","method_name":"makeHandle"}]}
+// EXPECT: rule=store-violations-engine severity=error message=resource
+// zwanzig-disable: unused-decl
+
+fn makeHandle() i32 {
+    return 1;
+}
+
+fn leakFromIdentifierModel() void {
+    const handle = makeHandle();
+    _ = handle;
+}


### PR DESCRIPTION
## Summary

Extracts shared project-aware import and call resolution helpers and reuses them from project-wide unused declarations, resource calls, stack escape, sentinel allocation, and deinit lifecycle checks.

Adds fixtures for identifier resource models, typed escape models, result-location sentinel preservation, and chained cleanup receiver detection.

Fixes #92
