### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-01
+
 ### Changed
 
 - Shared project-aware import and call resolution across resource, stack-escape, sentinel allocation, and cleanup lifecycle checks, improving precision for identifier calls, typed receivers, FQNs, field-chain receivers, and result-location contexts (#92).
@@ -199,7 +201,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release: Zig static analyzer MVP with the `empty-catch` rule, rule-selection flags, and source parsing cache.
 
-[Unreleased]: https://github.com/forketyfork/zwanzig/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/forketyfork/zwanzig/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/forketyfork/zwanzig/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/forketyfork/zwanzig/compare/v0.12.2...v0.13.1
 [0.12.2]: https://github.com/forketyfork/zwanzig/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/forketyfork/zwanzig/compare/v0.12.0...v0.12.1

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zwanzig,
-    .version = "0.13.1",
+    .version = "0.14.0",
     .fingerprint = 0x82777a3c96d925a2,
     .minimum_zig_version = "0.15.2",
     .dependencies = .{},

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -59,7 +59,7 @@ Without arguments, zwanzig scans the current directory for `.zig` files. It skip
 Add zwanzig to your project:
 
 ```bash
-zig fetch --save https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.13.1.tar.gz
+zig fetch --save https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.14.0.tar.gz
 ```
 
 Then wire a lint step in your `build.zig`:


### PR DESCRIPTION
## Summary

Prepare the `v0.14.0` release by updating the package version, release notes, and install docs.

## Checks

- `just ci`
- `just release-check v0.14.0`
