### PR TITLE
Document external Zwanzig usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,14 @@ permissions:
   security-events: write
 
 jobs:
+  documentation-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check documented versions
+        run: ./scripts/check-doc-versions.sh
+
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -88,12 +96,16 @@ jobs:
 
   build:
     name: build
-    needs: [changes, build-matrix]
+    needs: [documentation-versions, changes, build-matrix]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check result
         run: |
+          if [[ "${{ needs.documentation-versions.result }}" != "success" ]]; then
+            echo "Documentation version check failed"
+            exit 1
+          fi
           if [[ "${{ needs.changes.outputs.code }}" == "false" ]]; then
             echo "Documentation-only change, skipping build"
             exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - README installation instructions now cover release binaries, Zig build dependencies, and GitHub Actions usage. (PR #103)
 
+### Fixed
+
+- `--target` no longer crashes after successful analysis when the target triple contains an ABI. (PR #103)
+
 ## [0.14.0] - 2026-06-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- README installation instructions now cover release binaries, Zig build dependencies, and GitHub Actions usage. (PR #103)
+
 ## [0.14.0] - 2026-06-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ zig build lint
 Download a pinned release binary before running Zwanzig. The Linux runner is x86_64, so it uses the Linux x86_64 archive:
 
 ```yaml
+name: Zwanzig
+
+on:
+  push:
+  pull_request:
+
 permissions:
   contents: read
   security-events: write
@@ -68,24 +74,29 @@ permissions:
 env:
   ZWANZIG_VERSION: v0.14.0
 
-steps:
-  - name: Install Zwanzig
-    run: |
-      archive="zwanzig-${ZWANZIG_VERSION}-linux-x86_64.tar.gz"
-      curl --fail --location --silent --show-error \
-        "https://github.com/forketyfork/zwanzig/releases/download/${ZWANZIG_VERSION}/${archive}" \
-        --output "${RUNNER_TEMP}/${archive}"
-      mkdir -p "${RUNNER_TEMP}/zwanzig"
-      tar -xzf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}/zwanzig"
-      echo "${RUNNER_TEMP}/zwanzig" >> "${GITHUB_PATH}"
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
 
-  - name: Run Zwanzig analysis
-    run: zwanzig --format sarif src/ > results.sarif || true
+      - name: Install Zwanzig
+        run: |
+          archive="zwanzig-${ZWANZIG_VERSION}-linux-x86_64.tar.gz"
+          curl --fail --location --silent --show-error \
+            "https://github.com/forketyfork/zwanzig/releases/download/${ZWANZIG_VERSION}/${archive}" \
+            --output "${RUNNER_TEMP}/${archive}"
+          mkdir -p "${RUNNER_TEMP}/zwanzig"
+          tar -xzf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}/zwanzig"
+          echo "${RUNNER_TEMP}/zwanzig" >> "${GITHUB_PATH}"
 
-  - name: Upload SARIF results
-    uses: github/codeql-action/upload-sarif@v4
-    with:
-      sarif_file: results.sarif
+      - name: Run Zwanzig analysis
+        run: zwanzig --format sarif src/ > results.sarif || true
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif
 ```
 
 Pinning the version keeps CI reproducible. Update `ZWANZIG_VERSION` when you want to adopt a newer release. The `|| true` lets the SARIF upload run when Zwanzig reports diagnostics.

--- a/README.md
+++ b/README.md
@@ -6,31 +6,89 @@
 
 Zwanzig is a static analyzer and linter for Zig code, combining fast AST/token rules with CFG-driven analysis built on ZIR output.
 
-## Quick usage
+## Installation and usage
 
-### Local
+### Release binary
+
+Download the archive for your platform from the [latest release](https://github.com/forketyfork/zwanzig/releases/latest):
+
+| Platform | Archive |
+| --- | --- |
+| Linux x86_64 | `zwanzig-vX.Y.Z-linux-x86_64.tar.gz` |
+| macOS ARM64 | `zwanzig-vX.Y.Z-macos-aarch64.tar.gz` |
+| Windows x86_64 | `zwanzig-vX.Y.Z-windows-x86_64.zip` |
+
+Extract the archive and either add its directory to `PATH` or invoke the executable directly:
 
 ```bash
-zig build
-zig build run -- src/
+./zwanzig src/
+```
+
+On Windows, run `.\zwanzig.exe src\` instead.
+
+### Zig build dependency
+
+Pin Zwanzig as a dependency in your Zig project. This command adds the dependency URL and content hash to `build.zig.zon`:
+
+```bash
+zig fetch --save=zwanzig https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.14.0.tar.gz
+```
+
+Add a lint step to `build.zig`:
+
+```zig
+const zwanzig = b.dependency("zwanzig", .{
+    .target = b.graph.host,
+    .optimize = .ReleaseFast,
+});
+const run_zwanzig = b.addRunArtifact(zwanzig.artifact("zwanzig"));
+run_zwanzig.addArgs(&.{"src"});
+
+const lint_step = b.step("lint", "Run Zwanzig");
+lint_step.dependOn(&run_zwanzig.step);
+```
+
+`b.graph.host` builds Zwanzig for the machine running the build, including when your project targets another platform. `ReleaseFast` avoids the substantial overhead of running the analyzer in Debug mode.
+
+Run the new step with:
+
+```bash
+zig build lint
 ```
 
 ### GitHub Actions (SARIF)
+
+Download a pinned release binary before running Zwanzig. The Linux runner is x86_64, so it uses the Linux x86_64 archive:
 
 ```yaml
 permissions:
   contents: read
   security-events: write
 
-- name: Run zwanzig analysis
-  run: |
-    zig build run -- --format sarif src/ > results.sarif || true
+env:
+  ZWANZIG_VERSION: v0.14.0
 
-- name: Upload SARIF results
-  uses: github/codeql-action/upload-sarif@v3
-  with:
-    sarif_file: results.sarif
+steps:
+  - name: Install Zwanzig
+    run: |
+      archive="zwanzig-${ZWANZIG_VERSION}-linux-x86_64.tar.gz"
+      curl --fail --location --silent --show-error \
+        "https://github.com/forketyfork/zwanzig/releases/download/${ZWANZIG_VERSION}/${archive}" \
+        --output "${RUNNER_TEMP}/${archive}"
+      mkdir -p "${RUNNER_TEMP}/zwanzig"
+      tar -xzf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}/zwanzig"
+      echo "${RUNNER_TEMP}/zwanzig" >> "${GITHUB_PATH}"
+
+  - name: Run Zwanzig analysis
+    run: zwanzig --format sarif src/ > results.sarif || true
+
+  - name: Upload SARIF results
+    uses: github/codeql-action/upload-sarif@v4
+    with:
+      sarif_file: results.sarif
 ```
+
+Pinning the version keeps CI reproducible. Update `ZWANZIG_VERSION` when you want to adopt a newer release. The `|| true` lets the SARIF upload run when Zwanzig reports diagnostics.
 
 ## Features
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,7 +1,7 @@
 # Release procedure
 
 1. Update `build.zig.zon` to the target version (e.g. `0.3.0`).
-2. Update any README tag references (e.g. the `zig fetch` example).
+2. Update version-pinned examples in `README.md` and `docs/USAGE.md`. Regular CI checks tagged source URLs and `ZWANZIG_VERSION` against `build.zig.zon`.
 3. Run the scripted checklist:
 
    ```bash

--- a/justfile
+++ b/justfile
@@ -25,6 +25,7 @@ lint:
         shellcheck validate.sh
     fi
     shellcheck scripts/*.sh
+    ./scripts/check-doc-versions.sh
 
     zig fmt --check src/
 

--- a/scripts/check-doc-versions.sh
+++ b/scripts/check-doc-versions.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 [vX.Y.Z]" >&2
+}
+
+if [ "$#" -gt 1 ]; then
+    usage
+    exit 2
+fi
+
+release_tag="${1:-}"
+if [ -n "$release_tag" ] && [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Invalid tag format: $release_tag" >&2
+    usage
+    exit 2
+fi
+
+version_line=$(grep -nE "^[[:space:]]*\\.version[[:space:]]*=" build.zig.zon | head -n1 || true)
+if [ -z "$version_line" ]; then
+    echo "Failed to locate .version in build.zig.zon" >&2
+    exit 1
+fi
+
+version=$(printf '%s' "$version_line" | sed -E 's/.*"([^"]+)".*/\1/')
+if [ -z "$version" ]; then
+    echo "Failed to parse version from build.zig.zon" >&2
+    exit 1
+fi
+
+package_tag="v$version"
+if [ -n "$release_tag" ] && [ "$package_tag" != "$release_tag" ]; then
+    echo "Version mismatch: build.zig.zon has $version but tag is $release_tag" >&2
+    exit 1
+fi
+expected_tag="${release_tag:-$package_tag}"
+
+check_version_references() {
+    local file="$1"
+    local description="$2"
+    local pattern="$3"
+    local -a found_tags=()
+
+    mapfile -t found_tags < <(
+        grep -oE "$pattern" "$file" |
+            grep -oE "v[0-9]+\\.[0-9]+\\.[0-9]+" |
+            sort -u || true
+    )
+
+    if [ "${#found_tags[@]}" -eq 0 ]; then
+        echo "$file: no $description references found" >&2
+        return 1
+    fi
+
+    local found_tag
+    for found_tag in "${found_tags[@]}"; do
+        if [ "$found_tag" != "$expected_tag" ]; then
+            echo "$file $description mismatch: found $found_tag, expected $expected_tag" >&2
+            return 1
+        fi
+    done
+}
+
+tag_pattern="refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+"
+actions_pattern="ZWANZIG_VERSION:[[:space:]]*v[0-9]+\\.[0-9]+\\.[0-9]+"
+
+check_version_references README.md "tagged source URL" "$tag_pattern"
+check_version_references docs/USAGE.md "tagged source URL" "$tag_pattern"
+check_version_references README.md ZWANZIG_VERSION "$actions_pattern"
+
+echo "Documentation versions match $expected_tag"

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -23,43 +23,7 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-version_line=$(grep -nE "^[[:space:]]*\\.version[[:space:]]*=" build.zig.zon | head -n1 || true)
-if [ -z "$version_line" ]; then
-    echo "Failed to locate .version in build.zig.zon" >&2
-    exit 1
-fi
-
-version=$(printf '%s' "$version_line" | sed -E 's/.*"([^"]+)".*/\1/')
-if [ -z "$version" ]; then
-    echo "Failed to parse version from build.zig.zon" >&2
-    exit 1
-fi
-
-if [ "v$version" != "$tag" ]; then
-    echo "Version mismatch: build.zig.zon has $version but tag is $tag" >&2
-    exit 1
-fi
-
-check_doc_tags() {
-    local file="$1"
-    local found
-    found=$(grep -oE "refs/tags/v[0-9]+\.[0-9]+\.[0-9]+" "$file" || true)
-    if [ -z "$found" ]; then
-        echo "Warning: no tag references found in $file" >&2
-        return 0
-    fi
-    local uniq_tags
-    mapfile -t uniq_tags < <(printf '%s\n' "$found" | sed 's#.*refs/tags/##' | sort -u)
-    for found_tag in "${uniq_tags[@]}"; do
-        if [ "$found_tag" != "$tag" ]; then
-            echo "$file tag mismatch: found $found_tag, expected $tag" >&2
-            return 1
-        fi
-    done
-}
-
-check_doc_tags README.md
-check_doc_tags docs/USAGE.md
+./scripts/check-doc-versions.sh "$tag"
 
 if command -v just >/dev/null 2>&1; then
     just ci

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -4,6 +4,7 @@ const Diagnostic = @import("../diagnostic.zig").Diagnostic;
 const file_discovery = @import("../file_discovery.zig");
 const build_options = @import("build_options");
 const config = @import("../config.zig");
+const build_metadata = @import("../build_metadata.zig");
 const args_mod = @import("args.zig");
 const merge_mod = @import("config_merge.zig");
 const registry = @import("registry.zig");
@@ -12,7 +13,9 @@ const Analyzer = analyzer_mod.Analyzer;
 const AnalysisResult = analyzer_mod.AnalysisResult;
 const CliArgs = args_mod.CliArgs;
 const CliError = args_mod.CliError;
+const BuildMetadata = build_metadata.BuildMetadata;
 const MergedConfig = merge_mod.MergedConfig;
+const TargetConfig = build_metadata.TargetConfig;
 const log = std.log.scoped(.zwanzig);
 
 const WorkerContext = struct {
@@ -233,7 +236,13 @@ fn discoverInputFiles(allocator: std.mem.Allocator, cli_args: CliArgs) []const [
     };
 }
 
-fn configureAnalyzer(analyzer: *Analyzer, cli_args: CliArgs, final_config: MergedConfig, allocator: std.mem.Allocator) !void {
+fn configureBuildMetadata(analyzer: *Analyzer, metadata: ?BuildMetadata) !void {
+    if (metadata) |value| {
+        try analyzer.setBuildMetadata(value);
+    }
+}
+
+fn configureAnalyzer(analyzer: *Analyzer, cli_args: CliArgs, final_config: MergedConfig) !void {
     analyzer.setToolVersion(build_options.version);
     try registry.registerDefaults(analyzer);
 
@@ -257,12 +266,7 @@ fn configureAnalyzer(analyzer: *Analyzer, cli_args: CliArgs, final_config: Merge
         });
     }
 
-    if (cli_args.build_metadata) |metadata_const| {
-        var metadata = metadata_const;
-        errdefer metadata.deinit(allocator);
-        try analyzer.setBuildMetadata(metadata);
-        metadata.deinit(allocator);
-    }
+    try configureBuildMetadata(analyzer, cli_args.build_metadata);
 
     if (cli_args.use_cache) {
         try analyzer.enableCache();
@@ -309,7 +313,7 @@ pub fn run() !void {
     var analyzer = Analyzer.init(allocator);
     defer analyzer.deinit();
 
-    try configureAnalyzer(&analyzer, cli_args, final_config, allocator);
+    try configureAnalyzer(&analyzer, cli_args, final_config);
 
     log.info("analyzing with {d} rule(s) using {d} thread(s)", .{ analyzer.totalCheckerCount(), cli_args.thread_count });
     try analyzeFilesParallel(&analyzer, files, cli_args.thread_count, allocator);
@@ -322,4 +326,20 @@ pub fn run() !void {
     if (analyzer.hasDiagnostics()) {
         std.process.exit(1);
     }
+}
+
+test "configureBuildMetadata borrows CLI metadata" {
+    const allocator = std.testing.allocator;
+
+    const target_config = try TargetConfig.fromTriple(allocator, "x86_64-linux-gnu");
+    var metadata = BuildMetadata.init(target_config, null);
+    defer metadata.deinit(allocator);
+
+    var analyzer = Analyzer.init(allocator);
+    defer analyzer.deinit();
+
+    try configureBuildMetadata(&analyzer, metadata);
+
+    try std.testing.expectEqualStrings("gnu", metadata.target.abi.?);
+    try std.testing.expectEqualStrings("gnu", analyzer.getBuildMetadata().?.target.abi.?);
 }


### PR DESCRIPTION
## Summary

The README's quick start assumed Zwanzig was running from its own source checkout, so its local and GitHub Actions examples did not work in another project.

This update documents the two supported external-project setups:

- download a published binary for Linux, macOS, or Windows
- pin Zwanzig as a Zig build dependency and expose a `zig build lint` step

The GitHub Actions example is now a complete workflow that installs a pinned Linux release binary before producing SARIF. The Zig build example targets the host machine, so the linter remains runnable when the project is cross-compiled, and uses `ReleaseFast` to avoid Debug-mode analysis overhead.

A lightweight CI job now checks the tagged source URLs and `ZWANZIG_VERSION` against `build.zig.zon`, including documentation-only pull requests. The release check reuses the same script, and `just lint` runs it locally.

While applying the same setup to Architect, an ABI-bearing `--target` exposed a metadata ownership bug. This PR also fixes that cleanup crash and adds a regression test.

## Validation

- `just test`
- `just lint`
- `actionlint .github/workflows/build.yml`
- validated the README workflow example with `actionlint`
- `./scripts/release-check.sh v0.14.0`
- `zig build run -- --target x86_64-linux-gnu src`
- downloaded and ran the published v0.14.0 macOS ARM64 binary
- fetched v0.14.0 from a clean Zig 0.15.2 project and ran its Zwanzig lint step
- confirmed an isolated stale `ZWANZIG_VERSION` fixture fails with the expected mismatch
