### PR TITLE
feat: support Zig 0.16 frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--version` now reports the embedded Zig frontend version. (PR #109)
 - A reproducible Zig 0.16.0 development shell and migration compatibility inventory are now available. (PR #110)
-- Source builds now support both Zig 0.15.2 and Zig 0.16.0 frontends, with the selected frontend reported by `--version`. (PR #110 follow-up)
+- Source builds now support both Zig 0.15.2 and Zig 0.16.0 frontends, with the selected frontend reported by `--version`. (PR #111; follow-up to PR #110)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--version` now reports the embedded Zig frontend version. (PR #109)
 - A reproducible Zig 0.16.0 development shell and migration compatibility inventory are now available. (PR #110)
+- Source builds now support both Zig 0.15.2 and Zig 0.16.0 frontends, with the selected frontend reported by `--version`. (PR #110 follow-up)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,16 @@ When asked to release: create a PR for the version bump, wait for required check
 
 ## Development Environment
 
-Uses Nix flakes for reproducible dev environment (Zig 0.15.2). Enter with:
+Uses Nix flakes for reproducible dev environments. The default shell uses Zig 0.15.2:
+
 ```bash
 nix develop
+```
+
+Use the Zig 0.16.0 shell to validate the alternate embedded frontend:
+
+```bash
+nix develop .#zig016
 ```
 
 ## Infrastructure

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Extract the archive and either add its directory to `PATH` or invoke the executa
 
 On Windows, run `.\zwanzig.exe src\` instead.
 
+### Zig frontend compatibility
+
+Zwanzig embeds the Zig frontend used to build it. Source builds support Zig 0.15.2 and Zig 0.16.0, and select the matching compatibility layer automatically. Run `zwanzig --version` to see which frontend a binary contains; use a binary built with the frontend version that matches the Zig language version used by your project.
+
 ### Zig build dependency
 
 Pin Zwanzig as a dependency in your Zig project. This command adds the dependency URL and content hash to `build.zig.zon`:

--- a/build.zig
+++ b/build.zig
@@ -1,10 +1,15 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const log_level = b.option(std.log.Level, "log-level", "Set log level") orelse .info;
     const version = readPackageVersion(b);
+    const main_source = if (builtin.zig_version.minor == 16)
+        b.path("src/main_0_16.zig")
+    else
+        b.path("src/main.zig");
 
     const options = b.addOptions();
     options.addOption(std.log.Level, "log_level", log_level);
@@ -17,7 +22,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const exe_module = b.createModule(.{
-        .root_source_file = b.path("src/main.zig"),
+        .root_source_file = main_source,
         .target = target,
         .optimize = optimize,
         .link_libc = true,
@@ -42,7 +47,7 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     const test_module = b.createModule(.{
-        .root_source_file = b.path("src/main.zig"),
+        .root_source_file = main_source,
         .target = target,
         .optimize = optimize,
         .link_libc = true,
@@ -84,36 +89,87 @@ pub fn build(b: *std.Build) void {
 
 fn readPackageVersion(b: *std.Build) []const u8 {
     const zon_path = "build.zig.zon";
-    const zon_contents = std.fs.cwd().readFileAllocOptions(
-        b.allocator,
-        zon_path,
-        1024 * 1024,
-        null,
-        .of(u8),
-        0,
-    ) catch |err| {
-        std.debug.panic("failed to read {s}: {s}", .{ zon_path, @errorName(err) });
-    };
+    const zon_contents: [:0]u8 = if (builtin.zig_version.minor == 16)
+        std.Io.Dir.cwd().readFileAllocOptions(
+            b.graph.io,
+            zon_path,
+            b.allocator,
+            std.Io.Limit.limited(1024 * 1024),
+            .of(u8),
+            0,
+        ) catch |err| {
+            std.debug.panic("failed to read {s}: {s}", .{ zon_path, @errorName(err) });
+        }
+    else
+        std.fs.cwd().readFileAllocOptions(
+            b.allocator,
+            zon_path,
+            1024 * 1024,
+            null,
+            .of(u8),
+            0,
+        ) catch |err| {
+            std.debug.panic("failed to read {s}: {s}", .{ zon_path, @errorName(err) });
+        };
+
     defer b.allocator.free(zon_contents);
 
     const PackageMetadata = struct {
         version: []const u8,
     };
 
-    const parsed = std.zon.parse.fromSlice(
-        PackageMetadata,
-        b.allocator,
-        zon_contents,
-        null,
-        .{ .ignore_unknown_fields = true },
-    ) catch |err| {
-        std.debug.panic("failed to parse {s}: {s}", .{ zon_path, @errorName(err) });
-    };
+    const parsed = if (builtin.zig_version.minor == 16)
+        std.zon.parse.fromSliceAlloc(
+            PackageMetadata,
+            b.allocator,
+            zon_contents,
+            null,
+            .{ .ignore_unknown_fields = true },
+        ) catch |err| {
+            std.debug.panic("failed to parse {s}: {s}", .{ zon_path, @errorName(err) });
+        }
+    else
+        std.zon.parse.fromSlice(
+            PackageMetadata,
+            b.allocator,
+            zon_contents,
+            null,
+            .{ .ignore_unknown_fields = true },
+        ) catch |err| {
+            std.debug.panic("failed to parse {s}: {s}", .{ zon_path, @errorName(err) });
+        };
     defer std.zon.parse.free(b.allocator, parsed);
 
     return b.allocator.dupe(u8, parsed.version) catch {
         std.debug.panic("failed to allocate package version", .{});
     };
+}
+
+fn addFixtureCheck(
+    b: *std.Build,
+    step: *std.Build.Step,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    dir_path: []const u8,
+    entry_name: []const u8,
+) void {
+    const full_path = b.allocator.alloc(u8, dir_path.len + 1 + entry_name.len) catch return;
+    @memcpy(full_path[0..dir_path.len], dir_path);
+    full_path[dir_path.len] = '/';
+    @memcpy(full_path[dir_path.len + 1 ..], entry_name);
+
+    const check_module = b.createModule(.{
+        .root_source_file = b.path(full_path),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const check = b.addObject(.{
+        .name = entry_name,
+        .root_module = check_module,
+    });
+
+    step.dependOn(&check.step);
 }
 
 fn addFixtureChecks(b: *std.Build, step: *std.Build.Step, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) void {
@@ -129,28 +185,26 @@ fn addFixtureChecks(b: *std.Build, step: *std.Build.Step, target: std.Build.Reso
     };
 
     for (fixture_dirs) |dir_path| {
-        var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch continue;
-        defer dir.close();
+        if (builtin.zig_version.minor == 16) {
+            var dir = std.Io.Dir.cwd().openDir(b.graph.io, dir_path, .{ .iterate = true }) catch continue;
+            defer dir.close(b.graph.io);
 
-        var iter = dir.iterate();
-        while (iter.next() catch null) |entry| {
-            if (entry.kind != .file) continue;
-            if (!std.mem.endsWith(u8, entry.name, ".zig")) continue;
+            var iter = dir.iterate();
+            while (iter.next(b.graph.io) catch null) |entry| {
+                if (entry.kind != .file) continue;
+                if (!std.mem.endsWith(u8, entry.name, ".zig")) continue;
+                addFixtureCheck(b, step, target, optimize, dir_path, entry.name);
+            }
+        } else {
+            var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch continue;
+            defer dir.close();
 
-            const full_path = std.fmt.allocPrint(b.allocator, "{s}/{s}", .{ dir_path, entry.name }) catch continue;
-
-            const check_module = b.createModule(.{
-                .root_source_file = b.path(full_path),
-                .target = target,
-                .optimize = optimize,
-            });
-
-            const check = b.addObject(.{
-                .name = entry.name,
-                .root_module = check_module,
-            });
-
-            step.dependOn(&check.step);
+            var iter = dir.iterate();
+            while (iter.next() catch null) |entry| {
+                if (entry.kind != .file) continue;
+                if (!std.mem.endsWith(u8, entry.name, ".zig")) continue;
+                addFixtureCheck(b, step, target, optimize, dir_path, entry.name);
+            }
         }
     }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,5 +1,21 @@
 # Development notes
 
+## Zig toolchains
+
+The default development shell uses Zig 0.15.2:
+
+```bash
+nix develop
+```
+
+The migration shell uses Zig 0.16.0:
+
+```bash
+nix develop .#zig016
+```
+
+Run `just test` and `just lint` in both shells when changing code that touches the embedded frontend or its compatibility adapters.
+
 ## macOS SDK workaround
 
 On macOS 26.x hosts the active `MacOSX.sdk/usr/lib/libSystem.tbd` only advertises `arm64e-macos`, so Zig 0.15.2 cannot link the build runner and emits a long list of undefined libSystem symbols (`__availability_version_check`, `_realpath$DARWIN_EXTSN`, etc.). Upstream tracker: <https://codeberg.org/ziglang/zig/issues/31756>.

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -17,6 +17,17 @@ Larger subsystems are split into focused submodules with thin facades:
 - `src/zir/` + `src/types/` - ZIR bridge implementation and shared type info (facade: `src/zir_bridge.zig`)
 - `src/lib.zig` - Public library exports for embedding
 
+#### Zig frontend compatibility
+
+Zwanzig supports the exact Zig 0.15.2 and 0.16.0 toolchains. `src/compat.zig`
+enforces that support boundary and selects the matching adapter at compile time.
+The I/O adapter carries the application context through file discovery,
+analysis, caching, formatting, and DOT output, while the executor and mutex
+adapters preserve parallel-analysis behavior across the two standard-library
+concurrency APIs. ZIR declaration and switch decoding is isolated in the
+version-specific adapters under `src/compat/`, so the analyzer and checkers
+operate on the shared type-information model.
+
 ### Core components
 
 #### Source parsing cache

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,6 +26,10 @@ Show the version:
 zwanzig --version
 ```
 
+### Zig frontend compatibility
+
+Zwanzig embeds the Zig frontend used to build it, so frontend-specific syntax is interpreted according to that embedded version. Source builds support exactly Zig 0.15.2 and Zig 0.16.0. The selected frontend is included in `--version`; when analyzing code that uses version-specific language features, use a Zwanzig binary built with the matching frontend.
+
 ### Files and directories
 
 ```bash

--- a/docs/ZIG_0_16_MIGRATION_PLAN.md
+++ b/docs/ZIG_0_16_MIGRATION_PLAN.md
@@ -483,8 +483,8 @@ Scope agreed in advance; task-level detail deliberately deferred until the Task 
 
 ### Phase 2 — Compat seams
 
-- **`build.zig` dual-toolchain support:** `comptime` branches on `builtin.zig_version` for the `std.fs.cwd()` calls (lines 87, 132). Cannot use `src/compat/` — build scripts compile before the project.
-- **Compat module layout** (extends Task 4's `src/compat.zig` into the selector):
+- [x] **`build.zig` dual-toolchain support:** `comptime` branches on `builtin.zig_version` for the `std.fs.cwd()` calls (lines 87, 132). Cannot use `src/compat/` — build scripts compile before the project.
+- [x] **Compat module layout** (extends Task 4's `src/compat.zig` into the selector):
 
   ```
   src/compat.zig                  # gate + comptime selection by builtin.zig_version
@@ -492,20 +492,20 @@ Scope agreed in advance; task-level detail deliberately deferred until the Task 
   src/compat/zig_0_16/{io,executor,zir}.zig
   ```
 
-- **I/O context:** an application context created in `src/main.zig` and threaded through `cli/run.zig` → analyzer → cache/config/discovery/formatters/DOT output. On 0.16 it owns a `std.Io` (from `std.Io.Threaded`); on 0.15.2 it exposes the same interface with no `Io` inside.
-- **Executor:** common interface over 0.15.2 `std.Thread.Pool`+`WaitGroup`+`Thread.Mutex` vs 0.16 `std.Io.Threaded`+`std.Io.Group`+`Io.Mutex` (all four 0.16 names verified present). `--threads <n>` maps to the pool size / `Io.Threaded` concurrency limit; behavior equivalence covered by tests.
-- **ZIR adapters:** move the `declIterator`-based decoding from `src/zir/bridge.zig` into `compat/zig_0_15/zir.zig`; implement `compat/zig_0_16/zir.zig` on `typeDecls`/`getStructDecl`/`getUnionDecl`/`getEnumDecl`/`getSwitchBlock` (names verified). Both adapters produce the existing `TypeInfo`/`DeclInfo`/`FnInfo` models from `src/zir/decls.zig`; the analyzer and checkers stay version-agnostic.
+- [x] **I/O context:** an application context created in `src/main.zig` and threaded through `cli/run.zig` → analyzer → cache/config/discovery/formatters/DOT output. On 0.16 it owns a `std.Io` (from `std.Io.Threaded`); on 0.15.2 it exposes the same interface with no `Io` inside.
+- [x] **Executor:** common interface over 0.15.2 `std.Thread.Pool`+`WaitGroup`+`Thread.Mutex` vs 0.16 `std.Io.Threaded`+`std.Io.Group`+`Io.Mutex` (all four 0.16 names verified present). `--threads <n>` maps to the pool size / `Io.Threaded` concurrency limit; behavior equivalence covered by tests.
+- [x] **ZIR adapters:** move the `declIterator`-based decoding from `src/zir/bridge.zig` into `compat/zig_0_15/zir.zig`; implement `compat/zig_0_16/zir.zig` on `typeDecls`/`getStructDecl`/`getUnionDecl`/`getEnumDecl`/`getSwitchBlock` (names verified). Both adapters produce the existing `TypeInfo`/`DeclInfo`/`FnInfo` models from `src/zir/decls.zig`; the analyzer and checkers stay version-agnostic.
 
 ### Phase 3 — Test matrix
 
 - Fixture matrix: shared-syntax fixtures asserted identical under both builds; a 0.15-only typed fixture (`@Type`); a 0.16-only typed fixture (`@Int`); tests asserting the mismatch cases fail with the explicit Task 1 error (not incomplete results). Version-conditional fixture registration via `src/compat.zig`.
-- Full `just test` + `just lint` green under both shells, including equivalence of rule results, caching, and `--threads` behavior.
+- [x] Full `just test` + `just lint` green under both shells, including equivalence of rule results, caching, and `--threads` behavior.
 
 ### Phase 4 — CI, distribution, docs
 
 - CI matrix: `just test` + `just lint` under `nix develop` (0.15.2) and `nix develop .#zig016`; one canonical `zig fmt --check` version (default 0.15.2 until switched deliberately — the two versions' formatters may disagree).
 - Release workflow: every platform × both frontends; artifact naming `zwanzig-<tag>-zig-<frontend>-<platform>` (e.g. `zwanzig-v0.15.0-zig-0.16.0-macos-aarch64`).
-- Docs: support matrix and "which binary do I download" guidance in `README.md`/`docs/USAGE.md`; CHANGELOG entries; update `CLAUDE.md` build instructions.
+- [x] Docs: support matrix and "which binary do I download" guidance in `README.md`/`docs/USAGE.md`; CHANGELOG entries; update `CLAUDE.md` build instructions.
 
 ### Open decision points (decide during Task 7 review)
 

--- a/src/analyzer.zig
+++ b/src/analyzer.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const Rule = @import("rule.zig").Rule;
 const Diagnostic = @import("rule.zig").Diagnostic;
 const Source = @import("source.zig").Source;
@@ -41,6 +42,7 @@ pub const Analyzer = struct {
     dump_exploded_graph_dir: ?[]const u8 = null,
     dump_annotated_cfg_dir: ?[]const u8 = null,
     dump_path_trace_dir: ?[]const u8 = null,
+    io_context: ?*compat.Context = null,
 
     pub fn init(allocator: std.mem.Allocator) Analyzer {
         return Analyzer{
@@ -49,6 +51,20 @@ pub const Analyzer = struct {
             .diagnostics = .empty,
             .rule_filter = .none,
         };
+    }
+
+    pub fn initWithContext(allocator: std.mem.Allocator, io_context: *compat.Context) Analyzer {
+        var analyzer = init(allocator);
+        analyzer.io_context = io_context;
+        return analyzer;
+    }
+
+    pub fn setIoContext(self: *Analyzer, io_context: *compat.Context) void {
+        self.io_context = io_context;
+    }
+
+    pub fn getIoContext(self: *Analyzer) *compat.Context {
+        return self.io_context orelse compat.defaultContext();
     }
 
     pub fn deinit(self: *Analyzer) void {
@@ -70,7 +86,7 @@ pub const Analyzer = struct {
     pub fn enableCache(self: *Analyzer) !void {
         self.use_cache = true;
         if (self.cache == null) {
-            self.cache = try Cache.init(self.allocator);
+            self.cache = try Cache.init(self.allocator, self.getIoContext());
         }
     }
 
@@ -213,7 +229,7 @@ pub const Analyzer = struct {
 
     pub fn analyzeProjectUnusedDecls(self: *Analyzer, files: []const []const u8) !void {
         if (!self.shouldRunProjectUnusedDecls()) return;
-        try project_unused_decl.analyze(self.allocator, files, &self.diagnostics);
+        try project_unused_decl.analyze(self.getIoContext(), self.allocator, files, &self.diagnostics);
         std.mem.sort(Diagnostic, self.diagnostics.items, {}, Diagnostic.lessThan);
     }
 
@@ -257,19 +273,10 @@ pub const Analyzer = struct {
     ) !AnalysisResult {
         log.debug("analyzeResult: start {s}", .{file_path});
 
-        const file = try std.fs.cwd().openFile(file_path, .{});
-        defer file.close();
-
         const max_size = 10 * 1024 * 1024;
         // Sentinel needed for Source.init; free accounts for sentinel byte below
         // zwanzig-disable-next-line: sentinel-alloc
-        const content = try file.readToEndAllocOptions(
-            scratch_allocator,
-            max_size,
-            null,
-            std.mem.Alignment.of(u8),
-            0,
-        );
+        const content = try compat.readFileAlloc(self.getIoContext(), scratch_allocator, file_path, max_size);
         defer scratch_allocator.free(content.ptr[0 .. content.len + 1]);
 
         var source = Source.init(scratch_allocator, file_path, content);
@@ -424,6 +431,7 @@ pub const Analyzer = struct {
             .dump_exploded_graph_dir = self.dump_exploded_graph_dir,
             .dump_annotated_cfg_dir = self.dump_annotated_cfg_dir,
             .dump_path_trace_dir = self.dump_path_trace_dir,
+            .io_context = self.getIoContext(),
         };
 
         // Run native checkers
@@ -452,13 +460,16 @@ pub const Analyzer = struct {
     };
 
     pub fn printResults(self: *Analyzer, format: OutputFormat) !void {
-        const stdout = std.fs.File.stdout().deprecatedWriter();
+        var stdout: compat.OutputWriter = undefined;
+        stdout.init(self.getIoContext(), false);
+        defer stdout.deinit();
+        const writer = stdout.writer();
 
         switch (format) {
-            .json => try self.printJsonResults(stdout),
+            .json => try self.printJsonResults(writer),
             .text => {
-                var formatter = ConsoleFormatter.init(self.allocator);
-                try formatter.write(stdout, self.diagnostics.items);
+                var formatter = ConsoleFormatter.init(self.allocator, self.getIoContext());
+                try formatter.write(writer, self.diagnostics.items);
             },
             .sarif => {
                 var formatter = SarifFormatter.init(
@@ -467,12 +478,13 @@ pub const Analyzer = struct {
                     self.tool_version,
                     self.diagnostics.items,
                 );
-                try formatter.write(stdout);
+                try formatter.write(writer);
             },
         }
+        try stdout.flush();
     }
 
-    fn printJsonResults(self: *Analyzer, writer: anytype) !void {
+    fn printJsonResults(self: *Analyzer, writer: *std.Io.Writer) !void {
         var alloc_writer: std.Io.Writer.Allocating = .init(self.allocator);
         defer alloc_writer.deinit();
 
@@ -628,7 +640,7 @@ test "Analyzer text output format" {
 
     var buffer: [512]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buffer);
-    var formatter = ConsoleFormatter.init(allocator);
+    var formatter = ConsoleFormatter.init(allocator, analyzer.getIoContext());
     try formatter.write(&writer, analyzer.diagnostics.items);
 
     const output = writer.buffered();
@@ -667,12 +679,12 @@ test "Analyzer SARIF output format" {
     try analyzer.diagnostics.append(allocator, diag1);
     try analyzer.diagnostics.append(allocator, diag2);
 
-    var output: std.ArrayList(u8) = .empty;
-    defer output.deinit(allocator);
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
     var formatter = SarifFormatter.init(allocator, &analyzer.checker_manager, analyzer.tool_version, analyzer.diagnostics.items);
-    try formatter.write(output.writer(allocator));
+    try formatter.write(&output.writer);
 
-    const result = output.items;
+    const result = output.written();
     try testing.expect(std.mem.indexOf(u8, result, "\"version\": \"2.1.0\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"$schema\":") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"runs\":") != null);
@@ -691,15 +703,14 @@ test "Analyzer cache enabled" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
-    var cache_dir = try std.fs.cwd().makeOpenPath("test-analyzer-cache", .{});
-    defer {
-        cache_dir.close();
-        std.fs.cwd().deleteTree("test-analyzer-cache") catch |err| {
-            log.warn("failed to clean up test directory: {}", .{err});
-        };
-    }
+    var io_context = try compat.Context.init(allocator, 1);
+    defer io_context.deinit();
+    try compat.makePath(&io_context, ".zwanzig-cache");
+    defer compat.deleteTree(&io_context, ".zwanzig-cache") catch |err| {
+        log.warn("failed to clean up test directory: {}", .{err});
+    };
 
-    var analyzer = Analyzer.init(allocator);
+    var analyzer = Analyzer.initWithContext(allocator, &io_context);
     defer analyzer.deinit();
 
     try analyzer.enableCache();
@@ -712,7 +723,9 @@ test "Analyzer cache hit still produces diagnostics" {
     const allocator = testing.allocator;
     const DupeImportRule = @import("rules/dupe_import.zig").DupeImportRule;
 
-    var tmp_dir = testing.tmpDir(.{});
+    var io_context = try compat.Context.init(allocator, 1);
+    defer io_context.deinit();
+    var tmp_dir = compat.TestDir.init();
     defer tmp_dir.cleanup();
 
     // File with duplicate imports to trigger a diagnostic
@@ -720,18 +733,16 @@ test "Analyzer cache hit still produces diagnostics" {
         \\const std = @import("std");
         \\const std2 = @import("std");
     ;
-    const test_file = try tmp_dir.dir.createFile("test.zig", .{});
-    try test_file.writeAll(test_file_content);
-    test_file.close();
+    try tmp_dir.writeFile("test.zig", test_file_content);
 
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const test_file_path = try tmp_dir.dir.realpath("test.zig", &path_buf);
+    const test_file_path = try std.fmt.bufPrint(&path_buf, "{s}/test.zig", .{tmp_dir.path()});
 
     var first_run_diag_count: usize = 0;
 
     // First run - populates cache
     {
-        var analyzer1 = Analyzer.init(allocator);
+        var analyzer1 = Analyzer.initWithContext(allocator, &io_context);
         defer analyzer1.deinit();
         try analyzer1.enableCache();
         try analyzer1.registerRule(&DupeImportRule.rule);
@@ -743,7 +754,7 @@ test "Analyzer cache hit still produces diagnostics" {
 
     // Second run - should hit cache but still produce same diagnostics
     {
-        var analyzer2 = Analyzer.init(allocator);
+        var analyzer2 = Analyzer.initWithContext(allocator, &io_context);
         defer analyzer2.deinit();
         try analyzer2.enableCache();
         try analyzer2.registerRule(&DupeImportRule.rule);

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const log = std.log.scoped(.cache);
+const compat = @import("compat.zig");
 const BuildMetadata = @import("build_metadata.zig").BuildMetadata;
 
 const CacheError = error{
@@ -76,18 +76,19 @@ const CacheEntry = struct {
     timestamp: i64,
     data_len: u32,
 
-    pub fn init(key: CacheKey, data_len: u32) CacheEntry {
+    const header_len = 144;
+
+    pub fn init(key: CacheKey, data_len: u32, timestamp: i64) CacheEntry {
         return CacheEntry{
             .version = cache_version,
             .key = key,
-            .timestamp = std.time.timestamp(),
+            .timestamp = timestamp,
             .data_len = data_len,
         };
     }
 
-    pub fn writeToFile(self: CacheEntry, file: std.fs.File) !void {
-        // Header: version(4) + file_hash(32) + target_hash(32) + version_hash(32) + config_hash(32) + timestamp(8) + data_len(4) = 144 bytes
-        var buf: [4 + 32 + 32 + 32 + 32 + 8 + 4]u8 = undefined;
+    pub fn encode(self: CacheEntry) [header_len]u8 {
+        var buf: [header_len]u8 = undefined;
         std.mem.writeInt(u32, buf[0..4], self.version, .little);
         @memcpy(buf[4..36], &self.key.file_hash);
         @memcpy(buf[36..68], &self.key.target_hash);
@@ -95,16 +96,12 @@ const CacheEntry = struct {
         @memcpy(buf[100..132], &self.key.config_hash);
         std.mem.writeInt(i64, buf[132..140], self.timestamp, .little);
         std.mem.writeInt(u32, buf[140..144], self.data_len, .little);
-        try file.writeAll(&buf);
+        // Returning the header by value copies the local array to the caller.
+        // zwanzig-disable-next-line: stack-escape-engine
+        return buf;
     }
 
-    pub fn readFromFile(file: std.fs.File) !CacheEntry {
-        var buf: [4 + 32 + 32 + 32 + 32 + 8 + 4]u8 = undefined;
-        const bytes_read = try file.readAll(&buf);
-        if (bytes_read != buf.len) {
-            return CacheError.CacheCorrupted;
-        }
-
+    pub fn decode(buf: *const [header_len]u8) !CacheEntry {
         const version = std.mem.readInt(u32, buf[0..4], .little);
         if (version != cache_version) {
             return CacheError.VersionMismatch;
@@ -125,14 +122,20 @@ const CacheEntry = struct {
 
 pub const Cache = struct {
     allocator: std.mem.Allocator,
-    cache_dir: ?std.fs.Dir,
-    mutex: std.Thread.Mutex = .{},
+    io_context: *compat.Context,
+    cache_dir: ?[]u8,
+    mutex: compat.Mutex = compat.initMutex(),
 
-    pub fn init(allocator: std.mem.Allocator) !Cache {
-        const cache_dir = std.fs.cwd().makeOpenPath(cache_dir_name, .{ .iterate = true }) catch |err| {
+    pub fn init(allocator: std.mem.Allocator, io_context: *compat.Context) !Cache {
+        return initAt(allocator, io_context, cache_dir_name);
+    }
+
+    pub fn initAt(allocator: std.mem.Allocator, io_context: *compat.Context, cache_dir_path: []const u8) !Cache {
+        compat.makePath(io_context, cache_dir_path) catch |err| {
             switch (err) {
                 error.AccessDenied => return Cache{
                     .allocator = allocator,
+                    .io_context = io_context,
                     .cache_dir = null,
                 },
                 else => return err,
@@ -141,13 +144,14 @@ pub const Cache = struct {
 
         return Cache{
             .allocator = allocator,
-            .cache_dir = cache_dir,
+            .io_context = io_context,
+            .cache_dir = try allocator.dupe(u8, cache_dir_path),
         };
     }
 
     pub fn deinit(self: *Cache) void {
-        if (self.cache_dir) |*dir| {
-            dir.close();
+        if (self.cache_dir) |dir| {
+            self.allocator.free(dir);
         }
     }
 
@@ -175,22 +179,26 @@ pub const Cache = struct {
             return null;
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        try compat.lockMutex(&self.mutex, self.io_context);
+        defer compat.unlockMutex(&self.mutex, self.io_context);
 
         var path_buf: [256]u8 = undefined;
         const cache_path = try Cache.getCachePath(key, &path_buf);
+        var full_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const full_path = try std.fmt.bufPrint(&full_path_buf, "{s}/{s}", .{ self.cache_dir.?, cache_path });
 
-        const file = self.cache_dir.?.openFile(cache_path, .{}) catch |err| {
+        const contents = compat.readFileAlloc(self.io_context, self.allocator, full_path, 10 * 1024 * 1024) catch |err| {
             return switch (err) {
                 error.FileNotFound => null,
                 error.AccessDenied => CacheError.AccessDenied,
                 else => err,
             };
         };
-        defer file.close();
+        defer self.allocator.free(contents.ptr[0 .. contents.len + 1]);
 
-        const entry = CacheEntry.readFromFile(file) catch |err| {
+        if (contents.len < CacheEntry.header_len) return null;
+        const header: *const [CacheEntry.header_len]u8 = @ptrCast(contents.ptr);
+        const entry = CacheEntry.decode(header) catch |err| {
             return switch (err) {
                 error.VersionMismatch, error.CacheCorrupted => null,
                 else => err,
@@ -202,15 +210,12 @@ pub const Cache = struct {
             return null;
         }
 
-        const data = try self.allocator.alloc(u8, entry.data_len);
-        errdefer self.allocator.free(data);
+        const data_start = CacheEntry.header_len;
+        const data_end = std.math.add(usize, data_start, entry.data_len) catch return null;
+        if (data_end > contents.len) return null;
 
-        const bytes_read = try file.readAll(data);
-        if (bytes_read != entry.data_len) {
-            // Incomplete read indicates corruption; treat as cache miss
-            self.allocator.free(data);
-            return null;
-        }
+        const data = try self.allocator.alloc(u8, entry.data_len);
+        @memcpy(data, contents[data_start..data_end]);
 
         return data;
     }
@@ -220,18 +225,21 @@ pub const Cache = struct {
             return;
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        try compat.lockMutex(&self.mutex, self.io_context);
+        defer compat.unlockMutex(&self.mutex, self.io_context);
 
         var path_buf: [256]u8 = undefined;
         const cache_path = try Cache.getCachePath(key, &path_buf);
+        var full_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const full_path = try std.fmt.bufPrint(&full_path_buf, "{s}/{s}", .{ self.cache_dir.?, cache_path });
 
-        const file = try self.cache_dir.?.createFile(cache_path, .{});
-        defer file.close();
-
-        const entry = CacheEntry.init(key, @intCast(data.len));
-        try entry.writeToFile(file);
-        try file.writeAll(data);
+        const entry = CacheEntry.init(key, @intCast(data.len), compat.timestamp(self.io_context));
+        const header = entry.encode();
+        const contents = try self.allocator.alloc(u8, header.len + data.len);
+        defer self.allocator.free(contents);
+        @memcpy(contents[0..header.len], &header);
+        @memcpy(contents[header.len..], data);
+        try compat.writeFile(self.io_context, full_path, contents);
     }
 
     pub fn invalidate(self: *Cache, key: CacheKey) !void {
@@ -239,13 +247,16 @@ pub const Cache = struct {
             return;
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        try compat.lockMutex(&self.mutex, self.io_context);
+        defer compat.unlockMutex(&self.mutex, self.io_context);
 
         var path_buf: [256]u8 = undefined;
         const cache_path = try Cache.getCachePath(key, &path_buf);
 
-        self.cache_dir.?.deleteFile(cache_path) catch |err| {
+        var full_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const full_path = try std.fmt.bufPrint(&full_path_buf, "{s}/{s}", .{ self.cache_dir.?, cache_path });
+
+        compat.deleteFile(self.io_context, full_path) catch |err| {
             if (err != error.FileNotFound) {
                 return err;
             }
@@ -257,8 +268,8 @@ pub const Cache = struct {
             return;
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        try compat.lockMutex(&self.mutex, self.io_context);
+        defer compat.unlockMutex(&self.mutex, self.io_context);
 
         var files_to_delete: std.ArrayList([]const u8) = .empty;
         defer {
@@ -268,8 +279,10 @@ pub const Cache = struct {
             files_to_delete.deinit(self.allocator);
         }
 
-        var iter = self.cache_dir.?.iterate();
-        while (try iter.next()) |entry| {
+        var directory = try compat.openDir(self.io_context, self.cache_dir.?, true);
+        defer compat.closeDir(self.io_context, &directory);
+
+        while (try compat.nextDir(self.io_context, &directory)) |entry| {
             if (entry.kind == .file and std.mem.endsWith(u8, entry.name, ".cache")) {
                 const name_copy = try self.allocator.dupe(u8, entry.name);
                 try files_to_delete.append(self.allocator, name_copy);
@@ -277,7 +290,9 @@ pub const Cache = struct {
         }
 
         for (files_to_delete.items) |name| {
-            try self.cache_dir.?.deleteFile(name);
+            var full_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const full_path = try std.fmt.bufPrint(&full_path_buf, "{s}/{s}", .{ self.cache_dir.?, name });
+            try compat.deleteFile(self.io_context, full_path);
         }
     }
 };
@@ -359,42 +374,27 @@ test "CacheKey: deterministic across runs" {
 }
 
 test "CacheEntry: write and read" {
-    const allocator = std.testing.allocator;
     const rules = [_][]const u8{"rule1"};
     const key = CacheKey.init("test", null, "1.0.0", false, &rules);
-    const entry = CacheEntry.init(key, 42);
-
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    const file = try tmp_dir.dir.createFile("test.cache", .{ .read = true });
-    defer file.close();
-
-    try entry.writeToFile(file);
-
-    try file.seekTo(0);
-    const read_entry = try CacheEntry.readFromFile(file);
+    const entry = CacheEntry.init(key, 42, 123);
+    const encoded = entry.encode();
+    const read_entry = try CacheEntry.decode(&encoded);
 
     try std.testing.expectEqual(entry.version, read_entry.version);
     try std.testing.expectEqual(entry.data_len, read_entry.data_len);
     try std.testing.expect(entry.key.eql(read_entry.key));
-    _ = allocator;
+    try std.testing.expectEqual(entry.timestamp, read_entry.timestamp);
 }
 
 test "Cache: put and get" {
     const allocator = std.testing.allocator;
 
-    const cache_dir = try std.fs.cwd().makeOpenPath("test-cache-tmp", .{ .iterate = true });
-    defer {
-        std.fs.cwd().deleteTree("test-cache-tmp") catch |err| {
-            log.warn("failed to clean up test directory: {}", .{err});
-        };
-    }
+    var io_context = try compat.Context.init(allocator, 1);
+    defer io_context.deinit();
+    var temp_dir = compat.TestDir.init();
+    defer temp_dir.cleanup();
 
-    var cache = Cache{
-        .allocator = allocator,
-        .cache_dir = cache_dir,
-    };
+    var cache = try Cache.initAt(allocator, &io_context, temp_dir.path());
     defer cache.deinit();
 
     const rules = [_][]const u8{"rule1"};
@@ -415,8 +415,11 @@ test "Cache: put and get" {
 test "Cache: get non-existent key returns null" {
     const allocator = std.testing.allocator;
 
+    var io_context = try compat.Context.init(allocator, 1);
+    defer io_context.deinit();
     var cache = Cache{
         .allocator = allocator,
+        .io_context = &io_context,
         .cache_dir = null,
     };
     defer cache.deinit();
@@ -431,17 +434,12 @@ test "Cache: get non-existent key returns null" {
 test "Cache: invalidate removes entry" {
     const allocator = std.testing.allocator;
 
-    const cache_dir = try std.fs.cwd().makeOpenPath("test-cache-tmp2", .{ .iterate = true });
-    defer {
-        std.fs.cwd().deleteTree("test-cache-tmp2") catch |err| {
-            log.warn("failed to clean up test directory: {}", .{err});
-        };
-    }
+    var io_context = try compat.Context.init(allocator, 1);
+    defer io_context.deinit();
+    var temp_dir = compat.TestDir.init();
+    defer temp_dir.cleanup();
 
-    var cache = Cache{
-        .allocator = allocator,
-        .cache_dir = cache_dir,
-    };
+    var cache = try Cache.initAt(allocator, &io_context, temp_dir.path());
     defer cache.deinit();
 
     const rules = [_][]const u8{"rule1"};
@@ -457,17 +455,12 @@ test "Cache: invalidate removes entry" {
 test "Cache: clear removes all entries" {
     const allocator = std.testing.allocator;
 
-    const cache_dir = try std.fs.cwd().makeOpenPath("test-cache-tmp3", .{ .iterate = true });
-    defer {
-        std.fs.cwd().deleteTree("test-cache-tmp3") catch |err| {
-            log.warn("failed to clean up test directory: {}", .{err});
-        };
-    }
+    var io_context = try compat.Context.init(allocator, 1);
+    defer io_context.deinit();
+    var temp_dir = compat.TestDir.init();
+    defer temp_dir.cleanup();
 
-    var cache = Cache{
-        .allocator = allocator,
-        .cache_dir = cache_dir,
-    };
+    var cache = try Cache.initAt(allocator, &io_context, temp_dir.path());
     defer cache.deinit();
 
     const rules = [_][]const u8{"rule1"};
@@ -489,8 +482,11 @@ test "Cache: clear removes all entries" {
 test "Cache: handles access denied gracefully" {
     const allocator = std.testing.allocator;
 
+    var io_context = try compat.Context.init(allocator, 1);
+    defer io_context.deinit();
     var cache = Cache{
         .allocator = allocator,
+        .io_context = &io_context,
         .cache_dir = null,
     };
     defer cache.deinit();

--- a/src/cfg/builder.zig
+++ b/src/cfg/builder.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
 const graph = @import("graph.zig");
 const dot = @import("dot.zig");
 const builder_control_flow = @import("builder/control_flow.zig");
@@ -30,6 +31,7 @@ pub const CfgBuilder = struct {
     type_context: ?*TypeContext = null,
     /// Optional directory to dump CFG DOT files for visualization.
     dump_cfg_dir: ?[]const u8 = null,
+    io_context: *compat.Context = compat.defaultContext(),
     pub const type_annotation = builder_type_annotation.mixin(@This());
     pub const statements = builder_statements.mixin(@This());
     pub const control_flow = builder_control_flow.mixin(@This());
@@ -67,6 +69,10 @@ pub const CfgBuilder = struct {
     /// When set, buildFromFn automatically writes DOT files after building CFGs.
     pub fn setDumpCfgDir(self: *CfgBuilder, dir: ?[]const u8) void {
         self.dump_cfg_dir = dir;
+    }
+
+    pub fn setIoContext(self: *CfgBuilder, io_context: *compat.Context) void {
+        self.io_context = io_context;
     }
 
     /// Build CFG for a function body starting at the given AST node.
@@ -160,7 +166,7 @@ pub const CfgBuilder = struct {
 
         // Auto-dump CFG if configured
         if (self.dump_cfg_dir) |dir| {
-            dot.writeToFile(&cfg, dir, source.getFilePath(), self.allocator);
+            dot.writeToFile(&cfg, dir, source.getFilePath(), self.io_context, self.allocator);
         }
 
         return cfg;

--- a/src/cfg/dot.zig
+++ b/src/cfg/dot.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
 const graph = @import("graph.zig");
 const Cfg = graph.Cfg;
 const ids = @import("../ids.zig");
@@ -10,10 +11,9 @@ const log = std.log.scoped(.cfg_dot);
 /// The output can be rendered with Graphviz: `dot -Tpng file.dot -o file.png`
 /// or viewed at online tools like edotor.net or viz-js.com
 fn generate(cfg: *const Cfg, allocator: std.mem.Allocator) ![]const u8 {
-    var buffer: std.ArrayList(u8) = .empty;
-    errdefer buffer.deinit(allocator);
-
-    const writer = buffer.writer(allocator);
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    const writer = &output.writer;
 
     // Header
     try writer.writeAll("digraph CFG {\n");
@@ -68,7 +68,7 @@ fn generate(cfg: *const Cfg, allocator: std.mem.Allocator) ![]const u8 {
 
     try writer.writeAll("}\n");
 
-    return buffer.toOwnedSlice(allocator);
+    return output.toOwnedSlice();
 }
 
 /// Write a CFG to a DOT file.
@@ -77,6 +77,7 @@ pub fn writeToFile(
     cfg: *const Cfg,
     dir: []const u8,
     source_path: []const u8,
+    io_context: *compat.Context,
     allocator: std.mem.Allocator,
 ) void {
     const dot = generate(cfg, allocator) catch |err| {
@@ -97,7 +98,7 @@ pub fn writeToFile(
         return;
     };
 
-    dot_helpers.writeDotFile(dir, file_path, dot) catch |err| {
+    dot_helpers.writeDotFile(io_context, dir, file_path, dot) catch |err| {
         log.warn("failed to write CFG DOT file {s}: {}", .{ file_path, err });
         return;
     };

--- a/src/checker.zig
+++ b/src/checker.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const Source = @import("source.zig").Source;
 const diagnostic_mod = @import("diagnostic.zig");
 pub const Diagnostic = diagnostic_mod.Diagnostic;
@@ -100,6 +101,7 @@ pub const CheckerContext = struct {
     /// Directory to dump path trace DOT files.
     /// Shows paths to violations with state evolution.
     dump_path_trace_dir: ?[]const u8 = null,
+    io_context: *compat.Context = compat.defaultContext(),
 
     /// Check if type information is available.
     pub fn hasTypeInfo(self: *const CheckerContext) bool {
@@ -143,6 +145,7 @@ pub const CheckerContext = struct {
     pub fn createCfgBuilder(self: *const CheckerContext, allocator: std.mem.Allocator) CfgBuilder {
         var builder = CfgBuilder.init(allocator);
         builder.setDumpCfgDir(self.dump_cfg_dir);
+        builder.setIoContext(self.io_context);
         builder.setTypeContext(self.type_context);
         return builder;
     }

--- a/src/checkers/divide_by_zero_engine.zig
+++ b/src/checkers/divide_by_zero_engine.zig
@@ -82,13 +82,13 @@ pub const DivideByZeroEngineChecker = struct {
         }
 
         if (context.dump_exploded_graph_dir) |dir| {
-            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_annotated_cfg_dir) |dir| {
-            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_path_trace_dir) |dir| {
-            engine_mod.dot.writePathTracesToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writePathTracesToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
 
         if (!run_ok) return;

--- a/src/checkers/empty_catch_engine.zig
+++ b/src/checkers/empty_catch_engine.zig
@@ -190,13 +190,13 @@ pub const EmptyCatchEngineChecker = struct {
 
         // Dump visualizations if requested
         if (context.dump_exploded_graph_dir) |dir| {
-            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_annotated_cfg_dir) |dir| {
-            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_path_trace_dir) |dir| {
-            engine_mod.dot.writePathTracesToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writePathTracesToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
 
         // Examine CFG nodes for catch_expr with empty handlers

--- a/src/checkers/optional_unwrap_engine.zig
+++ b/src/checkers/optional_unwrap_engine.zig
@@ -93,13 +93,13 @@ pub const OptionalUnwrapEngineChecker = struct {
 
         // Dump visualizations if requested
         if (context.dump_exploded_graph_dir) |dir| {
-            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_annotated_cfg_dir) |dir| {
-            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_path_trace_dir) |dir| {
-            engine_mod.dot.writePathTracesToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writePathTracesToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
 
         if (!run_ok) return;

--- a/src/checkers/slice_bounds_engine.zig
+++ b/src/checkers/slice_bounds_engine.zig
@@ -82,13 +82,13 @@ pub const SliceBoundsEngineChecker = struct {
         }
 
         if (context.dump_exploded_graph_dir) |dir| {
-            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_annotated_cfg_dir) |dir| {
-            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_path_trace_dir) |dir| {
-            engine_mod.dot.writePathTracesToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writePathTracesToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
 
         if (!run_ok) return;

--- a/src/checkers/store_violations_engine.zig
+++ b/src/checkers/store_violations_engine.zig
@@ -91,13 +91,13 @@ pub const StoreViolationsEngineChecker = struct {
 
         // Dump visualizations if requested
         if (context.dump_exploded_graph_dir) |dir| {
-            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_annotated_cfg_dir) |dir| {
-            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_path_trace_dir) |dir| {
-            engine_mod.dot.writePathTracesToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writePathTracesToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
 
         if (!run_ok) return;

--- a/src/checkers/swallowed_error.zig
+++ b/src/checkers/swallowed_error.zig
@@ -90,13 +90,13 @@ pub const SwallowedErrorChecker = struct {
 
         // Dump visualizations if requested
         if (context.dump_exploded_graph_dir) |dir| {
-            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeExplodedGraphToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_annotated_cfg_dir) |dir| {
-            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writeAnnotatedCfgToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
         if (context.dump_path_trace_dir) |dir| {
-            engine_mod.dot.writePathTracesToFile(engine.getGraph(), dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
+            engine_mod.dot.writePathTracesToFile(engine.getGraph(), context.io_context, dir, src.getFilePath(), cfg_handle.cfg.fn_name, allocator);
         }
 
         // Examine CFG nodes for catch_expr with swallowed errors

--- a/src/cli/config_merge.zig
+++ b/src/cli/config_merge.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
 const args_mod = @import("args.zig");
 const config = @import("../config.zig");
 const RuleFilter = @import("../rule_filter.zig").RuleFilter;
@@ -22,10 +23,10 @@ fn defaultRuleFilter(allocator: std.mem.Allocator) !RuleFilter {
     return .{ .blocklist = rule_names };
 }
 
-pub fn mergeConfig(allocator: std.mem.Allocator, cli_args: CliArgs) !MergedConfig {
+pub fn mergeConfig(io_context: *compat.Context, allocator: std.mem.Allocator, cli_args: CliArgs) !MergedConfig {
     const config_path = cli_args.config_path orelse ".zwanzig.json";
 
-    var loaded_config = config.loadConfig(allocator, config_path) catch |err| {
+    var loaded_config = config.loadConfig(io_context, allocator, config_path) catch |err| {
         if (err == config.ConfigError.FileNotFound and cli_args.config_path == null) {
             const rule_filter = switch (cli_args.rule_filter) {
                 .none => try defaultRuleFilter(allocator),
@@ -147,12 +148,13 @@ pub fn freeMergedConfig(allocator: std.mem.Allocator, cli_args: CliArgs, merged:
 
 test "mergeConfig: CLI overrides config allowlist" {
     const allocator = std.testing.allocator;
+    const io_context = compat.defaultContext();
 
-    var tmp_dir = std.testing.tmpDir(.{});
+    var tmp_dir = compat.TestDir.init();
     defer tmp_dir.cleanup();
 
     var tmp_path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const tmp_path = try tmp_dir.dir.realpath(".", &tmp_path_buf);
+    const tmp_path = try std.fmt.bufPrint(&tmp_path_buf, "{s}", .{tmp_dir.path()});
 
     var config_path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const config_path = try std.fmt.bufPrint(&config_path_buf, "{s}/.zwanzig.json", .{tmp_path});
@@ -162,7 +164,7 @@ test "mergeConfig: CLI overrides config allowlist" {
         \\  "enabled_rules": ["empty-catch"]
         \\}
     ;
-    try tmp_dir.dir.writeFile(.{ .sub_path = ".zwanzig.json", .data = config_content });
+    try tmp_dir.writeFile(".zwanzig.json", config_content);
 
     const cli_allowlist = [_][]const u8{"dupe-import"};
     const cli_args = CliArgs{
@@ -182,7 +184,7 @@ test "mergeConfig: CLI overrides config allowlist" {
         .thread_count = 1,
     };
 
-    const result = try mergeConfig(allocator, cli_args);
+    const result = try mergeConfig(io_context, allocator, cli_args);
     defer freeMergedConfig(allocator, cli_args, result);
 
     switch (result.rule_filter) {
@@ -196,12 +198,13 @@ test "mergeConfig: CLI overrides config allowlist" {
 
 test "mergeConfig: uses config when no CLI filter" {
     const allocator = std.testing.allocator;
+    const io_context = compat.defaultContext();
 
-    var tmp_dir = std.testing.tmpDir(.{});
+    var tmp_dir = compat.TestDir.init();
     defer tmp_dir.cleanup();
 
     var tmp_path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const tmp_path = try tmp_dir.dir.realpath(".", &tmp_path_buf);
+    const tmp_path = try std.fmt.bufPrint(&tmp_path_buf, "{s}", .{tmp_dir.path()});
 
     var config_path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const config_path = try std.fmt.bufPrint(&config_path_buf, "{s}/.zwanzig.json", .{tmp_path});
@@ -211,7 +214,7 @@ test "mergeConfig: uses config when no CLI filter" {
         \\  "disabled_rules": ["todo"]
         \\}
     ;
-    try tmp_dir.dir.writeFile(.{ .sub_path = ".zwanzig.json", .data = config_content });
+    try tmp_dir.writeFile(".zwanzig.json", config_content);
 
     const cli_args = CliArgs{
         .paths = &.{},
@@ -230,7 +233,7 @@ test "mergeConfig: uses config when no CLI filter" {
         .thread_count = 1,
     };
 
-    const result = try mergeConfig(allocator, cli_args);
+    const result = try mergeConfig(io_context, allocator, cli_args);
     defer freeMergedConfig(allocator, cli_args, result);
 
     switch (result.rule_filter) {

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const compat = @import("../compat.zig");
 const analyzer_mod = @import("../analyzer.zig");
 const Diagnostic = @import("../diagnostic.zig").Diagnostic;
 const file_discovery = @import("../file_discovery.zig");
@@ -12,7 +13,7 @@ const registry = @import("registry.zig");
 
 const Analyzer = analyzer_mod.Analyzer;
 const AnalysisResult = analyzer_mod.AnalysisResult;
-const CliArgs = args_mod.CliArgs;
+pub const CliArgs = args_mod.CliArgs;
 const CliError = args_mod.CliError;
 const BuildMetadata = build_metadata.BuildMetadata;
 const MergedConfig = merge_mod.MergedConfig;
@@ -43,12 +44,18 @@ fn workerTask(file_index: usize, ctx: *WorkerContext) void {
     }
 }
 
-fn workerTaskWrapper(file_index: usize, ctx: *WorkerContext, wg: *std.Thread.WaitGroup) void {
-    defer wg.finish();
+fn workerTaskAdapter(file_index: usize, context: *anyopaque) void {
+    const ctx: *WorkerContext = @ptrCast(@alignCast(context));
     workerTask(file_index, ctx);
 }
 
-fn analyzeFilesParallel(analyzer: *Analyzer, files: []const []const u8, thread_count: usize, allocator: std.mem.Allocator) !void {
+fn analyzeFilesParallel(
+    analyzer: *Analyzer,
+    files: []const []const u8,
+    thread_count: usize,
+    allocator: std.mem.Allocator,
+    io_context: *compat.Context,
+) !void {
     if (files.len == 0) return;
 
     const results = try allocator.alloc(?AnalysisResult, files.len);
@@ -66,29 +73,13 @@ fn analyzeFilesParallel(analyzer: *Analyzer, files: []const []const u8, thread_c
         .errors = errors,
     };
 
-    var pool: std.Thread.Pool = undefined;
-    try pool.init(.{
-        .allocator = allocator,
-        .n_jobs = @intCast(thread_count),
-    });
-    defer pool.deinit();
+    var executor = try compat.Executor.init(io_context, allocator, thread_count);
+    defer executor.deinit();
 
-    var wg: std.Thread.WaitGroup = .{};
-    var spawn_error: ?anyerror = null;
     for (0..files.len) |i| {
-        wg.start();
-        pool.spawn(workerTaskWrapper, .{ i, &ctx, &wg }) catch |err| {
-            wg.finish();
-            spawn_error = err;
-            break;
-        };
+        try executor.spawn(workerTaskAdapter, i, @ptrCast(&ctx));
     }
-
-    pool.waitAndWork(&wg);
-
-    if (spawn_error) |err| {
-        return err;
-    }
+    try executor.wait();
 
     var first_error: ?anyerror = null;
     for (0..files.len) |i| {
@@ -109,56 +100,76 @@ fn analyzeFilesParallel(analyzer: *Analyzer, files: []const []const u8, thread_c
     }
 }
 
-fn printUsage() !void {
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.writeAll("Usage: zwanzig [options] [path...]\n");
-    try stdout.writeAll("\nA static analyzer for Zig code.\n");
-    try stdout.writeAll("\nOptions:\n");
-    try stdout.writeAll("  -h, --help        Show this help message and exit\n");
-    try stdout.writeAll("  --version         Show version and exit\n");
-    try stdout.writeAll("  --file <path>     Specify a file or directory to analyze (can be repeated)\n");
-    try stdout.writeAll("  --do <rule>       Only run the specified rule (can be repeated)\n");
-    try stdout.writeAll("  --skip <rule>     Skip the specified rule (can be repeated)\n");
-    try stdout.writeAll("  --target <triple> Specify target triple (e.g., x86_64-linux-gnu)\n");
-    try stdout.writeAll("  --config <path>   Path to config file (default: .zwanzig.json)\n");
-    try stdout.writeAll("  --format <format> Output format: 'text', 'json', or 'sarif' (default: text)\n");
-    try stdout.writeAll("  --max-steps <n>   Max worklist steps per engine run\n");
-    try stdout.writeAll("  --max-states-per-point <n> Max unique states per CFG point\n");
-    try stdout.writeAll("  --use-widening    Enable widening for convergence (default: on)\n");
-    try stdout.writeAll("  --cache           Enable incremental caching\n");
-    try stdout.writeAll("  --threads <n>     Number of threads for parallel analysis (default: CPU count)\n");
-    try stdout.writeAll("  --dump-cfg <dir>  Dump CFG DOT files to directory for visualization\n");
-    try stdout.writeAll("  --dump-exploded-graph <dir>  Dump exploded graph (all states) as DOT\n");
-    try stdout.writeAll("  --dump-annotated-cfg <dir>   Dump CFG with state annotations as DOT\n");
-    try stdout.writeAll("  --dump-path-trace <dir>      Dump path traces to violations as DOT\n");
-    try stdout.writeAll("\n  Note: --do and --skip are mutually exclusive and override config file.\n");
-    try stdout.writeAll("\nArguments:\n");
-    try stdout.writeAll("  [path...]         Files or directories to analyze (default: current directory)\n");
-    try stdout.writeAll("\nIgnored directories:\n");
-    try stdout.writeAll("  zig-cache/, zig-out/, .zigmod/, .gyro/\n");
+fn printUsage(io_context: *compat.Context) !void {
+    var stdout: compat.OutputWriter = undefined;
+    stdout.init(io_context, false);
+    defer stdout.deinit();
+    const writer = stdout.writer();
+    try writer.writeAll("Usage: zwanzig [options] [path...]\n");
+    try writer.writeAll("\nA static analyzer for Zig code.\n");
+    try writer.writeAll("\nOptions:\n");
+    try writer.writeAll("  -h, --help        Show this help message and exit\n");
+    try writer.writeAll("  --version         Show version and exit\n");
+    try writer.writeAll("  --file <path>     Specify a file or directory to analyze (can be repeated)\n");
+    try writer.writeAll("  --do <rule>       Only run the specified rule (can be repeated)\n");
+    try writer.writeAll("  --skip <rule>     Skip the specified rule (can be repeated)\n");
+    try writer.writeAll("  --target <triple> Specify target triple (e.g., x86_64-linux-gnu)\n");
+    try writer.writeAll("  --config <path>   Path to config file (default: .zwanzig.json)\n");
+    try writer.writeAll("  --format <format> Output format: 'text', 'json', or 'sarif' (default: text)\n");
+    try writer.writeAll("  --max-steps <n>   Max worklist steps per engine run\n");
+    try writer.writeAll("  --max-states-per-point <n> Max unique states per CFG point\n");
+    try writer.writeAll("  --use-widening    Enable widening for convergence (default: on)\n");
+    try writer.writeAll("  --cache           Enable incremental caching\n");
+    try writer.writeAll("  --threads <n>     Number of threads for parallel analysis (default: CPU count)\n");
+    try writer.writeAll("  --dump-cfg <dir>  Dump CFG DOT files to directory for visualization\n");
+    try writer.writeAll("  --dump-exploded-graph <dir>  Dump exploded graph (all states) as DOT\n");
+    try writer.writeAll("  --dump-annotated-cfg <dir>   Dump CFG with state annotations as DOT\n");
+    try writer.writeAll("  --dump-path-trace <dir>      Dump path traces to violations as DOT\n");
+    try writer.writeAll("\n  Note: --do and --skip are mutually exclusive and override config file.\n");
+    try writer.writeAll("\nArguments:\n");
+    try writer.writeAll("  [path...]         Files or directories to analyze (default: current directory)\n");
+    try writer.writeAll("\nIgnored directories:\n");
+    try writer.writeAll("  zig-cache/, zig-out/, .zigmod/, .gyro/\n");
+    try stdout.flush();
 }
 
-fn printVersion() !void {
+fn printVersion(io_context: *compat.Context) !void {
     var buffer: [128]u8 = undefined;
     const message = try std.fmt.bufPrint(
         &buffer,
         "zwanzig {s} (Zig frontend {s})\n",
         .{ build_options.version, builtin.zig_version_string },
     );
-    try std.fs.File.stdout().writeAll(message);
+    var stdout: compat.OutputWriter = undefined;
+    stdout.init(io_context, false);
+    defer stdout.deinit();
+    try stdout.writer().writeAll(message);
+    try stdout.flush();
 }
 
-fn parseCliArgs(allocator: std.mem.Allocator, args: []const []const u8) CliArgs {
+fn writeError(io_context: *compat.Context, message: []const u8) void {
+    var stderr: compat.OutputWriter = undefined;
+    stderr.init(io_context, true);
+    defer stderr.deinit();
+    // This is already an error-reporting path; preserving the original error
+    // is more useful than replacing it with a failure to write stderr.
+    // zwanzig-disable-next-line: empty-catch-engine
+    stderr.writer().writeAll(message) catch {};
+    // zwanzig-disable-next-line: empty-catch-engine
+    stderr.flush() catch {};
+}
+
+pub fn parseCliArgs(io_context: *compat.Context, allocator: std.mem.Allocator, args: []const []const u8) CliArgs {
     // Check for --help or -h before parsing other arguments
     for (args[1..]) |arg| {
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
-            printUsage() catch |err| {
+            printUsage(io_context) catch |err| {
                 std.debug.print("Failed to print usage: {s}\n", .{@errorName(err)});
             };
             std.process.exit(0);
         }
         if (std.mem.eql(u8, arg, "--version")) {
-            printVersion() catch |err| {
+            printVersion(io_context) catch |err| {
                 std.debug.print("Failed to print version: {s}\n", .{@errorName(err)});
             };
             std.process.exit(0);
@@ -166,28 +177,27 @@ fn parseCliArgs(allocator: std.mem.Allocator, args: []const []const u8) CliArgs 
     }
 
     return args_mod.parseArgs(allocator, args) catch |err| {
-        const stderr = std.fs.File.stderr().deprecatedWriter();
         // zwanzig-disable: empty-catch-engine
         // We are on an error-exit path; failing to write to stderr (e.g. closed
         // pipe) must not mask the original error or crash the process.
         switch (err) {
             CliError.MutuallyExclusiveFlags => {
-                stderr.writeAll("Error: --do and --skip are mutually exclusive\n") catch {};
+                writeError(io_context, "Error: --do and --skip are mutually exclusive\n");
             },
             CliError.MissingFlagValue => {
-                stderr.writeAll("Error: Flag requires a value\n") catch {};
+                writeError(io_context, "Error: Flag requires a value\n");
             },
             CliError.OutOfMemory => {
-                stderr.writeAll("Error: Out of memory\n") catch {};
+                writeError(io_context, "Error: Out of memory\n");
             },
             CliError.InvalidTargetTriple => {
-                stderr.writeAll("Error: Invalid target triple format\n") catch {};
+                writeError(io_context, "Error: Invalid target triple format\n");
             },
             CliError.InvalidOutputFormat => {
-                stderr.writeAll("Error: Invalid output format (use 'text', 'json', or 'sarif')\n") catch {};
+                writeError(io_context, "Error: Invalid output format (use 'text', 'json', or 'sarif')\n");
             },
             CliError.InvalidNumericValue => {
-                stderr.writeAll("Error: Invalid numeric value for limit\n") catch {};
+                writeError(io_context, "Error: Invalid numeric value for limit\n");
             },
         }
         // zwanzig-enable: empty-catch-engine
@@ -195,25 +205,24 @@ fn parseCliArgs(allocator: std.mem.Allocator, args: []const []const u8) CliArgs 
     };
 }
 
-fn loadMergedConfig(allocator: std.mem.Allocator, cli_args: CliArgs) MergedConfig {
-    return merge_mod.mergeConfig(allocator, cli_args) catch |err| {
-        const stderr = std.fs.File.stderr().deprecatedWriter();
+fn loadMergedConfig(io_context: *compat.Context, allocator: std.mem.Allocator, cli_args: CliArgs) MergedConfig {
+    return merge_mod.mergeConfig(io_context, allocator, cli_args) catch |err| {
         // zwanzig-disable: empty-catch-engine
         switch (err) {
             config.ConfigError.InvalidJson => {
-                stderr.writeAll("Error: Invalid JSON in config file\n") catch {};
+                writeError(io_context, "Error: Invalid JSON in config file\n");
             },
             config.ConfigError.InvalidConfigFormat => {
-                stderr.writeAll("Error: Invalid config file format\n") catch {};
+                writeError(io_context, "Error: Invalid config file format\n");
             },
             config.ConfigError.MutuallyExclusiveFields => {
-                stderr.writeAll("Error: Config file has both enabled_rules and disabled_rules\n") catch {};
+                writeError(io_context, "Error: Config file has both enabled_rules and disabled_rules\n");
             },
             config.ConfigError.FileNotFound => {
-                stderr.writeAll("Error: Config file not found\n") catch {};
+                writeError(io_context, "Error: Config file not found\n");
             },
             config.ConfigError.OutOfMemory => {
-                stderr.writeAll("Error: Out of memory\n") catch {};
+                writeError(io_context, "Error: Out of memory\n");
             },
         }
         // zwanzig-enable: empty-catch-engine
@@ -221,19 +230,18 @@ fn loadMergedConfig(allocator: std.mem.Allocator, cli_args: CliArgs) MergedConfi
     };
 }
 
-fn discoverInputFiles(allocator: std.mem.Allocator, cli_args: CliArgs) []const []const u8 {
-    return file_discovery.discoverFiles(allocator, cli_args.paths) catch |err| {
-        const stderr = std.fs.File.stderr().deprecatedWriter();
+fn discoverInputFiles(io_context: *compat.Context, allocator: std.mem.Allocator, cli_args: CliArgs) []const []const u8 {
+    return file_discovery.discoverFiles(io_context, allocator, cli_args.paths) catch |err| {
         // zwanzig-disable: empty-catch-engine
         switch (err) {
             file_discovery.FileDiscoveryError.FileNotFound => {
-                stderr.writeAll("Error: File or directory not found\n") catch {};
+                writeError(io_context, "Error: File or directory not found\n");
             },
             file_discovery.FileDiscoveryError.AccessDenied => {
-                stderr.writeAll("Error: Access denied\n") catch {};
+                writeError(io_context, "Error: Access denied\n");
             },
             else => {
-                stderr.writeAll("Error: Failed to discover files\n") catch {};
+                writeError(io_context, "Error: Failed to discover files\n");
             },
         }
         // zwanzig-enable: empty-catch-engine
@@ -291,37 +299,30 @@ fn configureAnalyzer(analyzer: *Analyzer, cli_args: CliArgs, final_config: Merge
     }
 }
 
-pub fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{ .thread_safe = true }){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
-
-    const cli_args = parseCliArgs(allocator, args);
-    defer args_mod.freeCliArgs(allocator, cli_args);
-
-    const final_config = loadMergedConfig(allocator, cli_args);
+pub fn runParsed(allocator: std.mem.Allocator, cli_args: CliArgs, io_context: *compat.Context) !void {
+    const final_config = loadMergedConfig(io_context, allocator, cli_args);
     defer merge_mod.freeMergedConfig(allocator, cli_args, final_config);
 
-    const files = discoverInputFiles(allocator, cli_args);
+    const files = discoverInputFiles(io_context, allocator, cli_args);
     defer file_discovery.freeDiscoveredFiles(allocator, files);
     log.info("discovered {d} file(s)", .{files.len});
 
     if (files.len == 0) {
-        const stderr = std.fs.File.stderr().deprecatedWriter();
-        try stderr.writeAll("No .zig files found.\n");
+        var stderr: compat.OutputWriter = undefined;
+        stderr.init(io_context, true);
+        defer stderr.deinit();
+        try stderr.writer().writeAll("No .zig files found.\n");
+        try stderr.flush();
         return;
     }
 
-    var analyzer = Analyzer.init(allocator);
+    var analyzer = Analyzer.initWithContext(allocator, io_context);
     defer analyzer.deinit();
 
     try configureAnalyzer(&analyzer, cli_args, final_config);
 
     log.info("analyzing with {d} rule(s) using {d} thread(s)", .{ analyzer.totalCheckerCount(), cli_args.thread_count });
-    try analyzeFilesParallel(&analyzer, files, cli_args.thread_count, allocator);
+    try analyzeFilesParallel(&analyzer, files, cli_args.thread_count, allocator, io_context);
     try analyzer.analyzeProjectUnusedDecls(files);
     log.info("analysis complete", .{});
     analyzer.logAnalysisStats();

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -10,6 +10,7 @@ const builtin = @import("builtin");
 
 pub const supported_zig_versions = [_]std.SemanticVersion{
     .{ .major = 0, .minor = 15, .patch = 2 },
+    .{ .major = 0, .minor = 16, .patch = 0 },
 };
 
 comptime {
@@ -19,6 +20,67 @@ comptime {
     }
     if (!supported) {
         @compileError("zwanzig does not support Zig " ++ builtin.zig_version_string ++
-            "; supported versions: 0.15.2 (see docs/ZIG_0_16_MIGRATION_PLAN.md)");
+            "; supported versions: 0.15.2, 0.16.0 (see docs/ZIG_0_16_MIGRATION_PLAN.md)");
     }
+}
+
+pub const io = if (builtin.zig_version.minor == 16)
+    @import("compat/zig_0_16/io.zig")
+else
+    @import("compat/zig_0_15/io.zig");
+
+pub const zir = if (builtin.zig_version.minor == 16)
+    @import("compat/zig_0_16/zir.zig")
+else
+    @import("compat/zig_0_15/zir.zig");
+
+pub const Context = io.Context;
+pub const Executor = io.Executor;
+pub const Mutex = io.Mutex;
+pub const EntryKind = io.EntryKind;
+pub const DirectoryEntry = io.DirectoryEntry;
+pub const Directory = io.Directory;
+pub const OutputWriter = io.OutputWriter;
+pub const TestDir = io.TestDir;
+
+pub const TaskFn = io.TaskFn;
+
+pub const defaultContext = io.defaultContext;
+pub const initMutex = io.initMutex;
+pub const lockMutex = io.lockMutex;
+pub const unlockMutex = io.unlockMutex;
+pub const openDir = io.openDir;
+pub const closeDir = io.closeDir;
+pub const nextDir = io.nextDir;
+pub const readFileAlloc = io.readFileAlloc;
+pub const writeFile = io.writeFile;
+pub const makePath = io.makePath;
+pub const deleteFile = io.deleteFile;
+pub const deleteTree = io.deleteTree;
+pub const stat = io.stat;
+pub const timestamp = io.timestamp;
+
+test "Executor runs submitted tasks to completion" {
+    const allocator = std.testing.allocator;
+
+    var context = try Context.init(allocator, 2);
+    defer context.deinit();
+
+    var executor = try Executor.init(&context, allocator, 2);
+    defer executor.deinit();
+
+    var completed = std.atomic.Value(usize).init(0);
+    const Task = struct {
+        fn run(_: usize, raw_context: *anyopaque) void {
+            const counter: *std.atomic.Value(usize) = @ptrCast(@alignCast(raw_context));
+            _ = counter.fetchAdd(1, .monotonic);
+        }
+    };
+
+    for (0..4) |index| {
+        try executor.spawn(Task.run, index, @ptrCast(&completed));
+    }
+    try executor.wait();
+
+    try std.testing.expectEqual(@as(usize, 4), completed.load(.acquire));
 }

--- a/src/compat/zig_0_15/io.zig
+++ b/src/compat/zig_0_15/io.zig
@@ -1,0 +1,244 @@
+const std = @import("std");
+
+pub const Context = struct {
+    // Keep this non-zero-sized: callers pass the context by pointer to both
+    // version-specific implementations.
+    marker: u8 = 0,
+
+    pub fn init(_: std.mem.Allocator, _: usize) !Context {
+        return .{};
+    }
+
+    pub fn deinit(_: *Context) void {}
+};
+
+var default_context: Context = .{};
+
+pub fn defaultContext() *Context {
+    return &default_context;
+}
+
+pub const TaskFn = *const fn (usize, *anyopaque) void;
+
+const PendingTask = struct {
+    function: TaskFn,
+    index: usize,
+    context: *anyopaque,
+    wait_group: *std.Thread.WaitGroup,
+};
+
+fn runTask(task: PendingTask) void {
+    defer task.wait_group.finish();
+    task.function(task.index, task.context);
+}
+
+pub const Executor = struct {
+    allocator: std.mem.Allocator,
+    pool: *std.Thread.Pool,
+    wait_group: std.Thread.WaitGroup,
+
+    pub fn init(_: *Context, allocator: std.mem.Allocator, thread_count: usize) !Executor {
+        const pool = try allocator.create(std.Thread.Pool);
+        errdefer allocator.destroy(pool);
+        try pool.init(.{
+            .allocator = allocator,
+            .n_jobs = @intCast(thread_count),
+            .track_ids = true,
+        });
+        return .{
+            .allocator = allocator,
+            .pool = pool,
+            .wait_group = .{},
+        };
+    }
+
+    pub fn deinit(self: *Executor) void {
+        self.pool.deinit();
+        self.allocator.destroy(self.pool);
+    }
+
+    pub fn spawn(self: *Executor, function: TaskFn, index: usize, context: *anyopaque) !void {
+        self.wait_group.start();
+        self.pool.spawn(runTask, .{PendingTask{
+            .function = function,
+            .index = index,
+            .context = context,
+            .wait_group = &self.wait_group,
+        }}) catch |err| {
+            self.wait_group.finish();
+            return err;
+        };
+    }
+
+    pub fn wait(self: *Executor) !void {
+        self.pool.waitAndWork(&self.wait_group);
+    }
+};
+
+pub const Mutex = std.Thread.Mutex;
+
+pub fn initMutex() Mutex {
+    return .{};
+}
+
+pub fn lockMutex(mutex: *Mutex, _: *Context) !void {
+    mutex.lock();
+}
+
+pub fn unlockMutex(mutex: *Mutex, _: *Context) void {
+    mutex.unlock();
+}
+
+pub const EntryKind = enum {
+    file,
+    directory,
+    other,
+};
+
+pub const DirectoryEntry = struct {
+    name: []const u8,
+    kind: EntryKind,
+};
+
+pub const Directory = struct {
+    dir: std.fs.Dir,
+    iterator: ?std.fs.Dir.Iterator = null,
+};
+
+pub fn openDir(_: *Context, path: []const u8, iterate: bool) !Directory {
+    return .{
+        .dir = try std.fs.cwd().openDir(path, .{ .iterate = iterate }),
+    };
+}
+
+pub fn closeDir(_: *Context, directory: *Directory) void {
+    directory.dir.close();
+}
+
+pub fn nextDir(_: *Context, directory: *Directory) !?DirectoryEntry {
+    if (directory.iterator == null) {
+        directory.iterator = directory.dir.iterate();
+    }
+    const entry = try directory.iterator.?.next() orelse return null;
+    return .{
+        .name = entry.name,
+        .kind = switch (entry.kind) {
+            .file => .file,
+            .directory => .directory,
+            else => .other,
+        },
+    };
+}
+
+pub fn readFileAlloc(
+    _: *Context,
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    max_size: usize,
+) ![:0]u8 {
+    const file = if (std.fs.path.isAbsolute(path))
+        try std.fs.openFileAbsolute(path, .{})
+    else
+        try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+
+    return file.readToEndAllocOptions(
+        allocator,
+        max_size,
+        null,
+        std.mem.Alignment.of(u8),
+        0,
+    );
+}
+
+pub fn writeFile(_: *Context, path: []const u8, data: []const u8) !void {
+    const file = if (std.fs.path.isAbsolute(path))
+        try std.fs.createFileAbsolute(path, .{})
+    else
+        try std.fs.cwd().createFile(path, .{});
+    defer file.close();
+    try file.writeAll(data);
+}
+
+pub fn makePath(_: *Context, path: []const u8) !void {
+    try std.fs.cwd().makePath(path);
+}
+
+pub fn deleteFile(_: *Context, path: []const u8) !void {
+    if (std.fs.path.isAbsolute(path)) {
+        return std.fs.deleteFileAbsolute(path);
+    }
+    return std.fs.cwd().deleteFile(path);
+}
+
+pub fn deleteTree(_: *Context, path: []const u8) !void {
+    if (std.fs.path.isAbsolute(path)) {
+        return std.fs.deleteTreeAbsolute(path);
+    }
+    return std.fs.cwd().deleteTree(path);
+}
+
+pub fn stat(_: *Context, path: []const u8) !EntryKind {
+    const result = try std.fs.cwd().statFile(path);
+    return switch (result.kind) {
+        .file => .file,
+        .directory => .directory,
+        else => .other,
+    };
+}
+
+pub const OutputWriter = struct {
+    file: std.fs.File,
+    file_writer: std.fs.File.Writer,
+    buffer: [4096]u8,
+
+    pub fn init(self: *OutputWriter, _: *Context, stderr: bool) void {
+        self.file = if (stderr) std.fs.File.stderr() else std.fs.File.stdout();
+        self.file_writer = self.file.writer(&self.buffer);
+    }
+
+    pub fn writer(self: *OutputWriter) *std.Io.Writer {
+        return &self.file_writer.interface;
+    }
+
+    pub fn flush(self: *OutputWriter) std.Io.Writer.Error!void {
+        try self.file_writer.interface.flush();
+    }
+
+    pub fn deinit(self: *OutputWriter) void {
+        _ = self;
+    }
+};
+
+pub const TestDir = struct {
+    inner: std.testing.TmpDir,
+    path_buffer: [std.fs.max_path_bytes]u8,
+    path_len: usize,
+
+    pub fn init() TestDir {
+        var inner = std.testing.tmpDir(.{});
+        var path_buffer: [std.fs.max_path_bytes]u8 = undefined;
+        const resolved_path = inner.dir.realpath(".", &path_buffer) catch @panic("failed to resolve test directory");
+        return .{
+            .inner = inner,
+            .path_buffer = path_buffer,
+            .path_len = resolved_path.len,
+        };
+    }
+
+    pub fn path(self: *const TestDir) []const u8 {
+        return self.path_buffer[0..self.path_len];
+    }
+
+    pub fn writeFile(self: *TestDir, name: []const u8, data: []const u8) !void {
+        try self.inner.dir.writeFile(.{ .sub_path = name, .data = data });
+    }
+
+    pub fn cleanup(self: *TestDir) void {
+        self.inner.cleanup();
+    }
+};
+
+pub fn timestamp(_: *Context) i64 {
+    return std.time.timestamp();
+}

--- a/src/compat/zig_0_15/zir.zig
+++ b/src/compat/zig_0_15/zir.zig
@@ -19,6 +19,23 @@ pub fn enumDeclHasTagType(small: std.zig.Zir.Inst.EnumDecl.Small) bool {
     return small.has_tag_type;
 }
 
+pub fn enumDeclHasBodyLen(small: std.zig.Zir.Inst.EnumDecl.Small) bool {
+    return small.has_body_len;
+}
+
+test "enum body length is independent from tag type" {
+    const small: std.zig.Zir.Inst.EnumDecl.Small = .{
+        .has_tag_type = false,
+        .has_captures_len = false,
+        .has_body_len = true,
+        .has_fields_len = false,
+        .has_decls_len = false,
+        .name_strategy = .parent,
+        .nonexhaustive = false,
+    };
+    try std.testing.expect(enumDeclHasBodyLen(small));
+}
+
 pub fn appendDecls(
     allocator: std.mem.Allocator,
     zir: std.zig.Zir,

--- a/src/compat/zig_0_15/zir.zig
+++ b/src/compat/zig_0_15/zir.zig
@@ -1,0 +1,162 @@
+const std = @import("std");
+
+// Only the adapter matching the compiler frontend is selected by compat.zig.
+// zwanzig-disable: unused-decl
+
+pub fn structDeclHasBackingInt(small: std.zig.Zir.Inst.StructDecl.Small) bool {
+    return small.has_backing_int;
+}
+
+pub fn unionDeclHasTagType(small: std.zig.Zir.Inst.UnionDecl.Small) bool {
+    return small.has_tag_type;
+}
+
+pub fn unionDeclHasArgTypeBody(small: std.zig.Zir.Inst.UnionDecl.Small) bool {
+    return small.has_body_len;
+}
+
+pub fn enumDeclHasTagType(small: std.zig.Zir.Inst.EnumDecl.Small) bool {
+    return small.has_tag_type;
+}
+
+pub fn appendDecls(
+    allocator: std.mem.Allocator,
+    zir: std.zig.Zir,
+    type_inst: std.zig.Zir.Inst.Index,
+    declarations: *std.ArrayList(std.zig.Zir.Inst.Index),
+) !void {
+    var iterator = zir.declIterator(type_inst);
+    while (iterator.next()) |decl_inst| {
+        try declarations.append(allocator, decl_inst);
+    }
+}
+
+pub fn appendSwitchBodies(
+    allocator: std.mem.Allocator,
+    zir: std.zig.Zir,
+    switch_inst: std.zig.Zir.Inst.Index,
+    bodies: *std.ArrayList([]const std.zig.Zir.Inst.Index),
+) !void {
+    const inst_data = zir.instructions.items(.data)[@intFromEnum(switch_inst)].pl_node;
+    const tag = zir.instructions.items(.tag)[@intFromEnum(switch_inst)];
+    switch (tag) {
+        .switch_block, .switch_block_ref => try appendNormalSwitchBodies(allocator, zir, inst_data.payload_index, bodies),
+        .switch_block_err_union => try appendErrUnionSwitchBodies(allocator, zir, inst_data.payload_index, bodies),
+        else => unreachable,
+    }
+}
+
+fn appendNormalSwitchBodies(
+    allocator: std.mem.Allocator,
+    zir: std.zig.Zir,
+    payload_index: u32,
+    bodies: *std.ArrayList([]const std.zig.Zir.Inst.Index),
+) !void {
+    const extra = zir.extraData(std.zig.Zir.Inst.SwitchBlock, payload_index);
+    var extra_index: usize = extra.end;
+    const multi_cases_len = if (extra.data.bits.has_multi_cases) blk: {
+        const len = zir.extra[extra_index];
+        extra_index += 1;
+        break :blk len;
+    } else 0;
+
+    if (extra.data.bits.any_has_tag_capture) extra_index += 1;
+    if (extra.data.bits.special_prongs != .none) {
+        if (extra.data.bits.special_prongs.hasElse()) {
+            const prong_info: std.zig.Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
+            extra_index += 1;
+            const body = zir.bodySlice(extra_index, prong_info.body_len);
+            extra_index += body.len;
+            try bodies.append(allocator, body);
+        }
+        if (extra.data.bits.special_prongs.hasUnder()) {
+            var trailing_items_len: u32 = 0;
+            if (extra.data.bits.special_prongs.hasOneAdditionalItem()) {
+                extra_index += 1;
+            } else if (extra.data.bits.special_prongs.hasManyAdditionalItems()) {
+                const items_len = zir.extra[extra_index];
+                extra_index += 1;
+                const ranges_len = zir.extra[extra_index];
+                extra_index += 1;
+                trailing_items_len = items_len + ranges_len * 2;
+            }
+            const prong_info: std.zig.Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
+            extra_index += 1 + trailing_items_len;
+            const body = zir.bodySlice(extra_index, prong_info.body_len);
+            extra_index += body.len;
+            try bodies.append(allocator, body);
+        }
+    }
+
+    for (0..extra.data.bits.scalar_cases_len) |_| {
+        extra_index += 1;
+        const prong_info: std.zig.Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
+        extra_index += 1;
+        const body = zir.bodySlice(extra_index, prong_info.body_len);
+        extra_index += body.len;
+        try bodies.append(allocator, body);
+    }
+
+    for (0..multi_cases_len) |_| {
+        const items_len = zir.extra[extra_index];
+        extra_index += 1;
+        const ranges_len = zir.extra[extra_index];
+        extra_index += 1;
+        const prong_info: std.zig.Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
+        extra_index += 1 + items_len + ranges_len * 2;
+        const body = zir.bodySlice(extra_index, prong_info.body_len);
+        extra_index += body.len;
+        try bodies.append(allocator, body);
+    }
+}
+
+fn appendErrUnionSwitchBodies(
+    allocator: std.mem.Allocator,
+    zir: std.zig.Zir,
+    payload_index: u32,
+    bodies: *std.ArrayList([]const std.zig.Zir.Inst.Index),
+) !void {
+    const extra = zir.extraData(std.zig.Zir.Inst.SwitchBlockErrUnion, payload_index);
+    var extra_index: usize = extra.end;
+    const multi_cases_len = if (extra.data.bits.has_multi_cases) blk: {
+        const len = zir.extra[extra_index];
+        extra_index += 1;
+        break :blk len;
+    } else 0;
+
+    if (extra.data.bits.any_uses_err_capture) extra_index += 1;
+    const non_err_info: std.zig.Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
+    extra_index += 1;
+    const non_err_body = zir.bodySlice(extra_index, non_err_info.body_len);
+    extra_index += non_err_body.len;
+    try bodies.append(allocator, non_err_body);
+
+    if (extra.data.bits.has_else) {
+        const else_info: std.zig.Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
+        extra_index += 1;
+        const else_body = zir.bodySlice(extra_index, else_info.body_len);
+        extra_index += else_body.len;
+        try bodies.append(allocator, else_body);
+    }
+
+    for (0..extra.data.bits.scalar_cases_len) |_| {
+        extra_index += 1;
+        const prong_info: std.zig.Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
+        extra_index += 1;
+        const body = zir.bodySlice(extra_index, prong_info.body_len);
+        extra_index += body.len;
+        try bodies.append(allocator, body);
+    }
+
+    for (0..multi_cases_len) |_| {
+        const items_len = zir.extra[extra_index];
+        extra_index += 1;
+        const ranges_len = zir.extra[extra_index];
+        extra_index += 1;
+        const prong_info: std.zig.Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
+        extra_index += 1 + items_len + ranges_len * 2;
+        const body = zir.bodySlice(extra_index, prong_info.body_len);
+        extra_index += body.len;
+        try bodies.append(allocator, body);
+    }
+}

--- a/src/compat/zig_0_16/io.zig
+++ b/src/compat/zig_0_16/io.zig
@@ -1,0 +1,253 @@
+const std = @import("std");
+
+pub const Context = struct {
+    threaded: ?std.Io.Threaded,
+
+    pub fn init(allocator: std.mem.Allocator, thread_count: usize) !Context {
+        return .{
+            .threaded = .init(allocator, .{
+                .async_limit = .limited(thread_count),
+                .concurrent_limit = .limited(thread_count),
+            }),
+        };
+    }
+
+    pub fn deinit(self: *Context) void {
+        if (self.threaded) |*threaded| threaded.deinit();
+    }
+
+    pub fn io(self: *Context) std.Io {
+        return self.threaded.?.io();
+    }
+};
+
+var default_context: Context = .{
+    .threaded = .init_single_threaded,
+};
+
+pub fn defaultContext() *Context {
+    return &default_context;
+}
+
+pub const TaskFn = *const fn (usize, *anyopaque) void;
+
+const PendingTask = struct {
+    function: TaskFn,
+    index: usize,
+    context: *anyopaque,
+};
+
+fn runTask(task: PendingTask) void {
+    task.function(task.index, task.context);
+}
+
+pub const Executor = struct {
+    context: *Context,
+    group: std.Io.Group = .init,
+
+    pub fn init(context: *Context, _: std.mem.Allocator, _: usize) !Executor {
+        return .{ .context = context };
+    }
+
+    pub fn deinit(self: *Executor) void {
+        _ = self;
+    }
+
+    pub fn spawn(self: *Executor, function: TaskFn, index: usize, context: *anyopaque) !void {
+        self.group.async(self.context.io(), runTask, .{PendingTask{
+            .function = function,
+            .index = index,
+            .context = context,
+        }});
+    }
+
+    pub fn wait(self: *Executor) !void {
+        try self.group.await(self.context.io());
+    }
+};
+
+pub const Mutex = std.Io.Mutex;
+
+pub fn initMutex() Mutex {
+    return .init;
+}
+
+pub fn lockMutex(mutex: *Mutex, context: *Context) !void {
+    try mutex.lock(context.io());
+}
+
+pub fn unlockMutex(mutex: *Mutex, context: *Context) void {
+    mutex.unlock(context.io());
+}
+
+pub const EntryKind = enum {
+    file,
+    directory,
+    other,
+};
+
+pub const DirectoryEntry = struct {
+    name: []const u8,
+    kind: EntryKind,
+};
+
+pub const Directory = struct {
+    dir: std.Io.Dir,
+    iterator: ?std.Io.Dir.Iterator = null,
+};
+
+pub fn openDir(context: *Context, path: []const u8, iterate: bool) !Directory {
+    const dir = if (std.fs.path.isAbsolute(path))
+        try std.Io.Dir.openDirAbsolute(context.io(), path, .{ .iterate = iterate })
+    else
+        try std.Io.Dir.cwd().openDir(context.io(), path, .{ .iterate = iterate });
+    return .{
+        .dir = dir,
+    };
+}
+
+pub fn closeDir(context: *Context, directory: *Directory) void {
+    directory.dir.close(context.io());
+}
+
+pub fn nextDir(context: *Context, directory: *Directory) !?DirectoryEntry {
+    if (directory.iterator == null) {
+        directory.iterator = directory.dir.iterate();
+    }
+    const entry = try directory.iterator.?.next(context.io()) orelse return null;
+    return .{
+        .name = entry.name,
+        .kind = switch (entry.kind) {
+            .file => .file,
+            .directory => .directory,
+            else => .other,
+        },
+    };
+}
+
+pub fn readFileAlloc(
+    context: *Context,
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    max_size: usize,
+) ![:0]u8 {
+    if (std.fs.path.isAbsolute(path)) {
+        var file = try std.Io.Dir.openFileAbsolute(context.io(), path, .{});
+        defer file.close(context.io());
+        var reader = file.reader(context.io(), &.{});
+        return reader.interface.allocRemainingAlignedSentinel(
+            allocator,
+            std.Io.Limit.limited(max_size),
+            .of(u8),
+            0,
+            // The reader exposes the underlying failure through `reader.err`.
+            // zwanzig-disable-next-line: swallowed-error
+        ) catch |err| switch (err) {
+            error.ReadFailed => reader.err.?,
+            error.OutOfMemory, error.StreamTooLong => |e| e,
+        };
+    }
+
+    return std.Io.Dir.cwd().readFileAllocOptions(
+        context.io(),
+        path,
+        allocator,
+        std.Io.Limit.limited(max_size),
+        .of(u8),
+        0,
+    );
+}
+
+pub fn writeFile(context: *Context, path: []const u8, data: []const u8) !void {
+    var file = if (std.fs.path.isAbsolute(path))
+        try std.Io.Dir.createFileAbsolute(context.io(), path, .{})
+    else
+        try std.Io.Dir.cwd().createFile(context.io(), path, .{});
+    defer file.close(context.io());
+    try file.writeStreamingAll(context.io(), data);
+}
+
+pub fn makePath(context: *Context, path: []const u8) !void {
+    try std.Io.Dir.cwd().createDirPath(context.io(), path);
+}
+
+pub fn deleteFile(context: *Context, path: []const u8) !void {
+    if (std.fs.path.isAbsolute(path)) {
+        return std.Io.Dir.deleteFileAbsolute(context.io(), path);
+    }
+    return std.Io.Dir.cwd().deleteFile(context.io(), path);
+}
+
+pub fn deleteTree(context: *Context, path: []const u8) !void {
+    if (std.fs.path.isAbsolute(path)) {
+        return std.Io.Dir.cwd().deleteTree(context.io(), path);
+    }
+    return std.Io.Dir.cwd().deleteTree(context.io(), path);
+}
+
+pub fn stat(context: *Context, path: []const u8) !EntryKind {
+    const result = try std.Io.Dir.cwd().statFile(context.io(), path, .{});
+    return switch (result.kind) {
+        .file => .file,
+        .directory => .directory,
+        else => .other,
+    };
+}
+
+pub const OutputWriter = struct {
+    context: *Context,
+    file: std.Io.File,
+    file_writer: std.Io.File.Writer,
+    buffer: [4096]u8,
+
+    pub fn init(self: *OutputWriter, context: *Context, stderr: bool) void {
+        self.context = context;
+        self.file = if (stderr) std.Io.File.stderr() else std.Io.File.stdout();
+        self.file_writer = self.file.writer(context.io(), &self.buffer);
+    }
+
+    pub fn writer(self: *OutputWriter) *std.Io.Writer {
+        return &self.file_writer.interface;
+    }
+
+    pub fn flush(self: *OutputWriter) std.Io.Writer.Error!void {
+        try self.file_writer.interface.flush();
+    }
+
+    pub fn deinit(self: *OutputWriter) void {
+        _ = self;
+    }
+};
+
+pub const TestDir = struct {
+    inner: std.testing.TmpDir,
+    path_buffer: [std.fs.max_path_bytes]u8,
+    path_len: usize,
+
+    pub fn init() TestDir {
+        var inner = std.testing.tmpDir(.{});
+        var path_buffer: [std.fs.max_path_bytes]u8 = undefined;
+        const path_len = inner.dir.realPath(std.testing.io, &path_buffer) catch @panic("failed to resolve test directory");
+        return .{
+            .inner = inner,
+            .path_buffer = path_buffer,
+            .path_len = path_len,
+        };
+    }
+
+    pub fn path(self: *const TestDir) []const u8 {
+        return self.path_buffer[0..self.path_len];
+    }
+
+    pub fn writeFile(self: *TestDir, name: []const u8, data: []const u8) !void {
+        try self.inner.dir.writeFile(std.testing.io, .{ .sub_path = name, .data = data });
+    }
+
+    pub fn cleanup(self: *TestDir) void {
+        self.inner.cleanup();
+    }
+};
+
+pub fn timestamp(context: *Context) i64 {
+    return std.Io.Clock.real.now(context.io()).toSeconds();
+}

--- a/src/compat/zig_0_16/zir.zig
+++ b/src/compat/zig_0_16/zir.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+
+// Only the adapter matching the compiler frontend is selected by compat.zig.
+// zwanzig-disable: unused-decl
+
+pub fn structDeclHasBackingInt(small: std.zig.Zir.Inst.StructDecl.Small) bool {
+    return small.has_backing_int_type;
+}
+
+pub fn unionDeclHasTagType(small: std.zig.Zir.Inst.UnionDecl.Small) bool {
+    return small.kind.hasArgType();
+}
+
+pub fn unionDeclHasArgTypeBody(small: std.zig.Zir.Inst.UnionDecl.Small) bool {
+    return small.kind.hasArgType();
+}
+
+pub fn enumDeclHasTagType(small: std.zig.Zir.Inst.EnumDecl.Small) bool {
+    return small.has_tag_type;
+}
+
+pub fn appendDecls(
+    allocator: std.mem.Allocator,
+    zir: std.zig.Zir,
+    type_inst: std.zig.Zir.Inst.Index,
+    declarations: *std.ArrayList(std.zig.Zir.Inst.Index),
+) !void {
+    for (zir.typeDecls(type_inst)) |decl_inst| {
+        try declarations.append(allocator, decl_inst);
+    }
+}
+
+pub fn appendSwitchBodies(
+    allocator: std.mem.Allocator,
+    zir: std.zig.Zir,
+    switch_inst: std.zig.Zir.Inst.Index,
+    bodies: *std.ArrayList([]const std.zig.Zir.Inst.Index),
+) !void {
+    const switch_block = zir.getSwitchBlock(switch_inst);
+
+    if (switch_block.non_err_case) |case| {
+        try bodies.append(allocator, case.body);
+    }
+    if (switch_block.else_case) |case| {
+        try bodies.append(allocator, case.body);
+    }
+
+    var extra_index = switch_block.end;
+    var cases = switch_block.iterateCases();
+    while (cases.next()) |case| {
+        const prong_body = zir.bodySlice(extra_index, case.prong_info.body_len);
+        extra_index += prong_body.len;
+        try bodies.append(allocator, prong_body);
+
+        for (case.item_infos) |item| {
+            switch (item.unwrap()) {
+                .body_len => |body_len| {
+                    const body = zir.bodySlice(extra_index, body_len);
+                    extra_index += body.len;
+                    try bodies.append(allocator, body);
+                },
+                else => {},
+            }
+        }
+        for (case.range_infos) |range| {
+            for (range) |item| {
+                switch (item.unwrap()) {
+                    .body_len => |body_len| {
+                        const body = zir.bodySlice(extra_index, body_len);
+                        extra_index += body.len;
+                        try bodies.append(allocator, body);
+                    },
+                    else => {},
+                }
+            }
+        }
+    }
+}

--- a/src/compat/zig_0_16/zir.zig
+++ b/src/compat/zig_0_16/zir.zig
@@ -19,6 +19,23 @@ pub fn enumDeclHasTagType(small: std.zig.Zir.Inst.EnumDecl.Small) bool {
     return small.has_tag_type;
 }
 
+pub fn enumDeclHasBodyLen(small: std.zig.Zir.Inst.EnumDecl.Small) bool {
+    return small.has_tag_type;
+}
+
+test "enum body length follows tag type" {
+    const small: std.zig.Zir.Inst.EnumDecl.Small = .{
+        .has_captures_len = false,
+        .has_decls_len = false,
+        .has_fields_len = false,
+        .name_strategy = .parent,
+        .has_tag_type = true,
+        .nonexhaustive = false,
+        .any_field_values = false,
+    };
+    try std.testing.expect(enumDeclHasBodyLen(small));
+}
+
 pub fn appendDecls(
     allocator: std.mem.Allocator,
     zir: std.zig.Zir,

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const RuleFilter = @import("rule_filter.zig").RuleFilter;
 
 /// Resource model kind matching store.zig ResourceKind
@@ -195,19 +196,15 @@ pub const ConfigError = error{
     MutuallyExclusiveFields,
 };
 
-pub fn loadConfig(allocator: std.mem.Allocator, path: []const u8) ConfigError!Config {
-    const file = std.fs.cwd().openFile(path, .{}) catch {
-        return ConfigError.FileNotFound;
-    };
-    defer file.close();
-
-    const content = file.readToEndAlloc(allocator, 1024 * 1024) catch |err| {
+pub fn loadConfig(io_context: *compat.Context, allocator: std.mem.Allocator, path: []const u8) ConfigError!Config {
+    const content = compat.readFileAlloc(io_context, allocator, path, 1024 * 1024) catch |err| {
         return switch (err) {
+            error.FileNotFound => ConfigError.FileNotFound,
             error.OutOfMemory => ConfigError.OutOfMemory,
             else => ConfigError.InvalidJson,
         };
     };
-    defer allocator.free(content);
+    defer allocator.free(content.ptr[0 .. content.len + 1]);
 
     return parseConfig(allocator, content);
 }
@@ -696,7 +693,7 @@ test "parseConfig: enabled_rules contains non-string" {
 
 test "loadConfig: file not found" {
     const allocator = std.testing.allocator;
-    const result = loadConfig(allocator, "nonexistent.json");
+    const result = loadConfig(compat.defaultContext(), allocator, "nonexistent.json");
     try std.testing.expectError(ConfigError.FileNotFound, result);
 }
 

--- a/src/dot_helpers.zig
+++ b/src/dot_helpers.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const cfg_graph = @import("cfg/graph.zig");
 
 const EdgeKind = cfg_graph.EdgeKind;
@@ -22,11 +23,7 @@ pub fn stemFromPath(source_path: []const u8) []const u8 {
     return if (std.mem.lastIndexOf(u8, basename, ".")) |idx| basename[0..idx] else basename;
 }
 
-pub fn writeDotFile(dir: []const u8, file_path: []const u8, dot: []const u8) !void {
-    try std.fs.cwd().makePath(dir);
-
-    const file = try std.fs.cwd().createFile(file_path, .{});
-    defer file.close();
-
-    try file.writeAll(dot);
+pub fn writeDotFile(io_context: *compat.Context, dir: []const u8, file_path: []const u8, dot: []const u8) !void {
+    try compat.makePath(io_context, dir);
+    try compat.writeFile(io_context, file_path, dot);
 }

--- a/src/engine/dot.zig
+++ b/src/engine/dot.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
 const graph_mod = @import("graph.zig");
 const ExplodedGraph = graph_mod.ExplodedGraph;
 const state_mod = @import("state.zig");
@@ -21,9 +22,9 @@ fn generateExplodedGraph(
     graph: *const ExplodedGraph,
     allocator: std.mem.Allocator,
 ) ![]const u8 {
-    var buffer: std.ArrayList(u8) = .empty;
-    errdefer buffer.deinit(allocator);
-    const writer = buffer.writer(allocator);
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    const writer = &output.writer;
 
     try writer.writeAll("digraph ExplodedGraph {\n");
     try writer.writeAll("  rankdir=TB;\n");
@@ -75,12 +76,13 @@ fn generateExplodedGraph(
     }
 
     try writer.writeAll("}\n");
-    return buffer.toOwnedSlice(allocator);
+    return output.toOwnedSlice();
 }
 
 /// Write exploded graph to a DOT file.
 pub fn writeExplodedGraphToFile(
     graph: *const ExplodedGraph,
+    io_context: *compat.Context,
     dir: []const u8,
     source_path: []const u8,
     fn_name: ?[]const u8,
@@ -92,7 +94,7 @@ pub fn writeExplodedGraphToFile(
     };
     defer allocator.free(dot);
 
-    writeToFile(dot, dir, source_path, fn_name, "exploded", allocator);
+    writeToFile(dot, io_context, dir, source_path, fn_name, "exploded", allocator);
 }
 
 // ============================================================================
@@ -105,9 +107,9 @@ fn generateAnnotatedCfg(
     graph: *const ExplodedGraph,
     allocator: std.mem.Allocator,
 ) ![]const u8 {
-    var buffer: std.ArrayList(u8) = .empty;
-    errdefer buffer.deinit(allocator);
-    const writer = buffer.writer(allocator);
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    const writer = &output.writer;
 
     const cfg = graph.cfg;
 
@@ -191,12 +193,13 @@ fn generateAnnotatedCfg(
     }
 
     try writer.writeAll("}\n");
-    return buffer.toOwnedSlice(allocator);
+    return output.toOwnedSlice();
 }
 
 /// Write annotated CFG to a DOT file.
 pub fn writeAnnotatedCfgToFile(
     graph: *const ExplodedGraph,
+    io_context: *compat.Context,
     dir: []const u8,
     source_path: []const u8,
     fn_name: ?[]const u8,
@@ -208,7 +211,7 @@ pub fn writeAnnotatedCfgToFile(
     };
     defer allocator.free(dot);
 
-    writeToFile(dot, dir, source_path, fn_name, "annotated", allocator);
+    writeToFile(dot, io_context, dir, source_path, fn_name, "annotated", allocator);
 }
 
 // ============================================================================
@@ -221,9 +224,9 @@ fn generatePathTraces(
     graph: *const ExplodedGraph,
     allocator: std.mem.Allocator,
 ) ![]const u8 {
-    var buffer: std.ArrayList(u8) = .empty;
-    errdefer buffer.deinit(allocator);
-    const writer = buffer.writer(allocator);
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    const writer = &output.writer;
 
     var violation_nodes: std.ArrayList(u32) = .empty;
     defer violation_nodes.deinit(allocator);
@@ -297,12 +300,13 @@ fn generatePathTraces(
     }
 
     try writer.writeAll("}\n");
-    return buffer.toOwnedSlice(allocator);
+    return output.toOwnedSlice();
 }
 
 /// Write path traces to a DOT file.
 pub fn writePathTracesToFile(
     graph: *const ExplodedGraph,
+    io_context: *compat.Context,
     dir: []const u8,
     source_path: []const u8,
     fn_name: ?[]const u8,
@@ -314,7 +318,7 @@ pub fn writePathTracesToFile(
     };
     defer allocator.free(dot);
 
-    writeToFile(dot, dir, source_path, fn_name, "traces", allocator);
+    writeToFile(dot, io_context, dir, source_path, fn_name, "traces", allocator);
 }
 
 // ============================================================================
@@ -355,6 +359,7 @@ fn reconstructPath(
 /// Write DOT content to a file in the specified directory.
 fn writeToFile(
     dot: []const u8,
+    io_context: *compat.Context,
     dir: []const u8,
     source_path: []const u8,
     fn_name: ?[]const u8,
@@ -370,7 +375,7 @@ fn writeToFile(
     };
     defer allocator.free(file_path);
 
-    dot_helpers.writeDotFile(dir, file_path, dot) catch |err| {
+    dot_helpers.writeDotFile(io_context, dir, file_path, dot) catch |err| {
         log.warn("failed to write DOT file {s}: {}", .{ file_path, err });
         return;
     };

--- a/src/file_discovery.zig
+++ b/src/file_discovery.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const log = std.log.scoped(.file_discovery);
 
 pub const FileDiscoveryError = error{
@@ -16,7 +17,11 @@ const ignored_dirs = [_][]const u8{
     ".gyro",
 };
 
-pub fn discoverFiles(allocator: std.mem.Allocator, paths: []const []const u8) FileDiscoveryError![]const []const u8 {
+pub fn discoverFiles(
+    io_context: *compat.Context,
+    allocator: std.mem.Allocator,
+    paths: []const []const u8,
+) FileDiscoveryError![]const []const u8 {
     var files: std.ArrayList([]const u8) = .empty;
     errdefer {
         for (files.items) |file| {
@@ -27,20 +32,20 @@ pub fn discoverFiles(allocator: std.mem.Allocator, paths: []const []const u8) Fi
 
     if (paths.len == 0) {
         log.debug("discover: walking current directory", .{});
-        try walkDirectory(allocator, &files, ".");
+        try walkDirectory(io_context, allocator, &files, ".");
     } else {
         for (paths) |path| {
             log.debug("discover: input path {s}", .{path});
-            const stat = std.fs.cwd().statFile(path) catch |err| switch (err) {
+            const stat = compat.stat(io_context, path) catch |err| switch (err) {
                 error.FileNotFound => return FileDiscoveryError.FileNotFound,
                 error.AccessDenied => return FileDiscoveryError.AccessDenied,
                 error.NotDir => return FileDiscoveryError.NotDir,
                 else => return FileDiscoveryError.AccessDenied,
             };
 
-            if (stat.kind == .directory) {
+            if (stat == .directory) {
                 log.debug("discover: walking directory {s}", .{path});
-                try walkDirectory(allocator, &files, path);
+                try walkDirectory(io_context, allocator, &files, path);
             } else if (isZigFile(path)) {
                 log.debug("discover: adding file {s}", .{path});
                 const owned = try allocator.dupe(u8, path);
@@ -52,11 +57,17 @@ pub fn discoverFiles(allocator: std.mem.Allocator, paths: []const []const u8) Fi
     return files.toOwnedSlice(allocator);
 }
 
-fn walkDirectory(allocator: std.mem.Allocator, files: *std.ArrayList([]const u8), base_path: []const u8) FileDiscoveryError!void {
-    try walkDirectoryRecursive(allocator, files, base_path, null);
+fn walkDirectory(
+    io_context: *compat.Context,
+    allocator: std.mem.Allocator,
+    files: *std.ArrayList([]const u8),
+    base_path: []const u8,
+) FileDiscoveryError!void {
+    try walkDirectoryRecursive(io_context, allocator, files, base_path, null);
 }
 
 fn walkDirectoryRecursive(
+    io_context: *compat.Context,
     allocator: std.mem.Allocator,
     files: *std.ArrayList([]const u8),
     base_path: []const u8,
@@ -71,17 +82,16 @@ fn walkDirectoryRecursive(
     const dir_to_open = open_path orelse base_path;
     log.debug("walk: open dir {s}", .{dir_to_open});
 
-    var dir = std.fs.cwd().openDir(dir_to_open, .{ .iterate = true }) catch |err| switch (err) {
+    var dir = compat.openDir(io_context, dir_to_open, true) catch |err| switch (err) {
         error.AccessDenied => return FileDiscoveryError.AccessDenied,
         error.FileNotFound => return FileDiscoveryError.FileNotFound,
         error.NotDir => return FileDiscoveryError.NotDir,
         else => return FileDiscoveryError.AccessDenied,
     };
-    defer dir.close();
+    defer compat.closeDir(io_context, &dir);
 
-    var iter = dir.iterate();
     while (true) {
-        const entry = iter.next() catch return FileDiscoveryError.AccessDenied;
+        const entry = compat.nextDir(io_context, &dir) catch return FileDiscoveryError.AccessDenied;
         if (entry) |e| {
             if (e.kind == .directory) {
                 if (shouldIgnoreDir(e.name)) {
@@ -95,7 +105,7 @@ fn walkDirectoryRecursive(
                 defer allocator.free(new_relative);
 
                 log.debug("walk: enter dir {s}", .{new_relative});
-                try walkDirectoryRecursive(allocator, files, base_path, new_relative);
+                try walkDirectoryRecursive(io_context, allocator, files, base_path, new_relative);
             } else if (e.kind == .file and isZigFile(e.name)) {
                 const full_path = if (relative_path) |rel|
                     std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ base_path, rel, e.name }) catch return FileDiscoveryError.OutOfMemory
@@ -167,9 +177,10 @@ test "shouldIgnoreDir" {
 
 test "discoverFiles: explicit files" {
     const allocator = std.testing.allocator;
+    const io_context = compat.defaultContext();
 
     const paths = [_][]const u8{"src/main.zig"};
-    const files = try discoverFiles(allocator, &paths);
+    const files = try discoverFiles(io_context, allocator, &paths);
     defer freeDiscoveredFiles(allocator, files);
 
     try std.testing.expectEqual(@as(usize, 1), files.len);
@@ -178,9 +189,10 @@ test "discoverFiles: explicit files" {
 
 test "discoverFiles: walks directory" {
     const allocator = std.testing.allocator;
+    const io_context = compat.defaultContext();
 
     const paths = [_][]const u8{"src"};
-    const files = try discoverFiles(allocator, &paths);
+    const files = try discoverFiles(io_context, allocator, &paths);
     defer freeDiscoveredFiles(allocator, files);
 
     try std.testing.expect(files.len > 0);
@@ -197,9 +209,10 @@ test "discoverFiles: walks directory" {
 
 test "discoverFiles: empty paths walks current directory" {
     const allocator = std.testing.allocator;
+    const io_context = compat.defaultContext();
 
     const paths = [_][]const u8{};
-    const files = try discoverFiles(allocator, &paths);
+    const files = try discoverFiles(io_context, allocator, &paths);
     defer freeDiscoveredFiles(allocator, files);
 
     try std.testing.expect(files.len > 0);
@@ -207,9 +220,10 @@ test "discoverFiles: empty paths walks current directory" {
 
 test "discoverFiles: non-zig files filtered" {
     const allocator = std.testing.allocator;
+    const io_context = compat.defaultContext();
 
     const paths = [_][]const u8{"."};
-    const files = try discoverFiles(allocator, &paths);
+    const files = try discoverFiles(io_context, allocator, &paths);
     defer freeDiscoveredFiles(allocator, files);
 
     for (files) |f| {

--- a/src/formatters/console.zig
+++ b/src/formatters/console.zig
@@ -1,13 +1,16 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
 const Diagnostic = @import("../rule.zig").Diagnostic;
 
 pub const ConsoleFormatter = struct {
     allocator: std.mem.Allocator,
+    io_context: *compat.Context,
     file_cache: std.StringHashMap([]const u8),
 
-    pub fn init(allocator: std.mem.Allocator) ConsoleFormatter {
+    pub fn init(allocator: std.mem.Allocator, io_context: *compat.Context) ConsoleFormatter {
         return .{
             .allocator = allocator,
+            .io_context = io_context,
             .file_cache = std.StringHashMap([]const u8).init(allocator),
         };
     }
@@ -15,7 +18,7 @@ pub const ConsoleFormatter = struct {
     pub fn deinit(self: *ConsoleFormatter) void {
         var value_iter = self.file_cache.valueIterator();
         while (value_iter.next()) |value| {
-            self.allocator.free(value.*);
+            self.allocator.free(value.*.ptr[0 .. value.*.len + 1]);
         }
         self.file_cache.deinit();
     }
@@ -76,24 +79,12 @@ pub const ConsoleFormatter = struct {
             return cached;
         }
 
-        const file = if (std.fs.path.isAbsolute(file_path))
-            std.fs.openFileAbsolute(file_path, .{})
-        else
-            std.fs.cwd().openFile(file_path, .{});
-        const opened_file = file catch return null;
-        defer opened_file.close();
-
         const max_size = 10 * 1024 * 1024;
-        const loaded = opened_file.readToEndAllocOptions(
-            self.allocator,
-            max_size,
-            null,
-            std.mem.Alignment.of(u8),
-            null,
-        ) catch return null;
+        const loaded_with_sentinel = compat.readFileAlloc(self.io_context, self.allocator, file_path, max_size) catch return null;
+        const loaded = loaded_with_sentinel[0..loaded_with_sentinel.len];
 
         self.file_cache.put(file_path, loaded) catch {
-            self.allocator.free(loaded);
+            self.allocator.free(loaded_with_sentinel);
             return null;
         };
         return loaded;

--- a/src/formatters/console.zig
+++ b/src/formatters/console.zig
@@ -18,7 +18,7 @@ pub const ConsoleFormatter = struct {
     pub fn deinit(self: *ConsoleFormatter) void {
         var value_iter = self.file_cache.valueIterator();
         while (value_iter.next()) |value| {
-            self.allocator.free(value.*.ptr[0 .. value.*.len + 1]);
+            freeSentinelContent(self.allocator, value.*);
         }
         self.file_cache.deinit();
     }
@@ -84,12 +84,16 @@ pub const ConsoleFormatter = struct {
         const loaded = loaded_with_sentinel[0..loaded_with_sentinel.len];
 
         self.file_cache.put(file_path, loaded) catch {
-            self.allocator.free(loaded_with_sentinel);
+            freeSentinelContent(self.allocator, loaded_with_sentinel);
             return null;
         };
         return loaded;
     }
 };
+
+fn freeSentinelContent(allocator: std.mem.Allocator, content: []const u8) void {
+    allocator.free(content.ptr[0 .. content.len + 1]);
+}
 
 fn lineSliceFor(content: []const u8, line_number: usize) ?[]const u8 {
     var line_iter = std.mem.splitScalar(u8, content, '\n');
@@ -118,4 +122,9 @@ test "lineSliceFor strips CR from CRLF" {
     const content = "line1\r\nline2\r\n";
     try std.testing.expectEqualStrings("line1", lineSliceFor(content, 1).?);
     try std.testing.expectEqualStrings("line2", lineSliceFor(content, 2).?);
+}
+
+test "freeSentinelContent frees the sentinel byte" {
+    const content = try std.testing.allocator.allocSentinel(u8, 3, 0);
+    freeSentinelContent(std.testing.allocator, content);
 }

--- a/src/formatters/sarif.zig
+++ b/src/formatters/sarif.zig
@@ -137,12 +137,12 @@ test "SarifFormatter produces valid JSON" {
 
     var formatter = SarifFormatter.init(allocator, &manager, "1.0.0", &diagnostics);
 
-    var output: std.ArrayList(u8) = .empty;
-    defer output.deinit(allocator);
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
 
-    try formatter.write(output.writer(allocator));
+    try formatter.write(&output.writer);
 
-    const result = output.items;
+    const result = output.written();
     try testing.expect(std.mem.indexOf(u8, result, "\"version\": \"2.1.0\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"name\": \"Zwanzig\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"results\":") != null);
@@ -170,12 +170,12 @@ test "SarifFormatter escapes special characters" {
 
     var formatter = SarifFormatter.init(allocator, &manager, "1.0.0", &diagnostics);
 
-    var output: std.ArrayList(u8) = .empty;
-    defer output.deinit(allocator);
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
 
-    try formatter.write(output.writer(allocator));
+    try formatter.write(&output.writer);
 
-    const result = output.items;
+    const result = output.written();
     // Check that quotes and newlines are properly escaped
     try testing.expect(std.mem.indexOf(u8, result, "\\\"quotes\\\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\\n") != null);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -5,6 +5,7 @@ pub const checker = @import("checker.zig");
 pub const config = @import("config.zig");
 pub const analyzer = @import("analyzer.zig");
 pub const rule_filter = @import("rule_filter.zig");
+pub const compat = @import("compat.zig");
 
 comptime {
     _ = @import("compat.zig");

--- a/src/main_0_16.zig
+++ b/src/main_0_16.zig
@@ -12,6 +12,19 @@ pub const std_options = std.Options{
     .log_level = @enumFromInt(@intFromEnum(build_options.log_level)),
 };
 
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const args: []const []const u8 = try init.minimal.args.toSlice(init.arena.allocator());
+
+    const cli_args = cli_run.parseCliArgs(compat.defaultContext(), allocator, args);
+    defer args_mod.freeCliArgs(allocator, cli_args);
+
+    var io_context = try compat.Context.init(allocator, cli_args.thread_count);
+    defer io_context.deinit();
+
+    try cli_run.runParsed(allocator, cli_args, &io_context);
+}
+
 test {
     _ = @import("ir.zig");
     _ = @import("cfg.zig");
@@ -30,21 +43,4 @@ test {
     _ = @import("cli/config_merge.zig");
     _ = @import("cli/registry.zig");
     _ = @import("cli/run.zig");
-}
-
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{ .thread_safe = true }){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
-
-    const cli_args = cli_run.parseCliArgs(compat.defaultContext(), allocator, args);
-    defer args_mod.freeCliArgs(allocator, cli_args);
-
-    var io_context = try compat.Context.init(allocator, cli_args.thread_count);
-    defer io_context.deinit();
-
-    try cli_run.runParsed(allocator, cli_args, &io_context);
 }

--- a/src/project_unused_decl.zig
+++ b/src/project_unused_decl.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const ast_walk = @import("ast_walk.zig");
 const call_resolver = @import("analysis/call_resolver.zig");
 const Diagnostic = @import("diagnostic.zig").Diagnostic;
@@ -60,12 +61,14 @@ const DeclInfo = struct {
 };
 
 const ProjectContext = struct {
+    io_context: *compat.Context,
     allocator: std.mem.Allocator,
     files: []const import_resolver.File,
     api_roots: std.ArrayList(usize) = .empty,
 
-    fn init(allocator: std.mem.Allocator, files: []const import_resolver.File) ProjectContext {
+    fn init(io_context: *compat.Context, allocator: std.mem.Allocator, files: []const import_resolver.File) ProjectContext {
         return .{
+            .io_context = io_context,
             .allocator = allocator,
             .files = files,
         };
@@ -112,19 +115,10 @@ const ProjectContext = struct {
     fn collectExternalBuildRootSourceFiles(self: *ProjectContext, build_path: []const u8) !void {
         if (import_resolver.findFileIndexByPath(self.files, build_path) != null) return;
 
-        const file = std.fs.cwd().openFile(build_path, .{}) catch return;
-        defer file.close();
-
         const max_size = 10 * 1024 * 1024;
         // Sentinel needed for std.zig.Ast.parse; free accounts for sentinel byte below.
         // zwanzig-disable-next-line: sentinel-alloc
-        const content = try file.readToEndAllocOptions(
-            self.allocator,
-            max_size,
-            null,
-            std.mem.Alignment.of(u8),
-            0,
-        );
+        const content = compat.readFileAlloc(self.io_context, self.allocator, build_path, max_size) catch return;
         defer self.allocator.free(content.ptr[0 .. content.len + 1]);
 
         var tree = try std.zig.Ast.parse(self.allocator, content, .zig);
@@ -158,6 +152,7 @@ const ProjectContext = struct {
 };
 
 pub fn analyze(
+    io_context: *compat.Context,
     allocator: std.mem.Allocator,
     file_paths: []const []const u8,
     diagnostics: *std.ArrayList(Diagnostic),
@@ -173,19 +168,10 @@ pub fn analyze(
     for (file_paths) |path| {
         if (containsPath(files.items, path)) continue;
 
-        const file = try std.fs.cwd().openFile(path, .{});
-        defer file.close();
-
         const max_size = 10 * 1024 * 1024;
         // Sentinel needed for std.zig.Ast.parse; free accounts for sentinel byte below.
         // zwanzig-disable-next-line: sentinel-alloc
-        const content = try file.readToEndAllocOptions(
-            allocator,
-            max_size,
-            null,
-            std.mem.Alignment.of(u8),
-            0,
-        );
+        const content = try compat.readFileAlloc(io_context, allocator, path, max_size);
         errdefer allocator.free(content.ptr[0 .. content.len + 1]);
 
         var tree = try std.zig.Ast.parse(allocator, content, .zig);
@@ -207,7 +193,7 @@ pub fn analyze(
     const resolver_files = try makeResolverFiles(allocator, files.items);
     defer allocator.free(resolver_files);
 
-    var project = ProjectContext.init(allocator, resolver_files);
+    var project = ProjectContext.init(io_context, allocator, resolver_files);
     defer project.deinit();
     try project.collectApiRoots();
 

--- a/src/source.zig
+++ b/src/source.zig
@@ -98,7 +98,7 @@ pub const Source = struct {
 
     /// Attempt to load ZIR-based type information for this source.
     /// This is a lazy operation - ZIR is only generated on first access.
-    /// Returns null if ZIR generation fails (e.g., due to parse errors).
+    /// Returns null if parsing or AstGen fails, including unsupported syntax.
     /// Subsequent calls return the cached result.
     pub fn zirBridge(self: *Source) ?*const ZirBridge {
         if (!self.zir_load_attempted) {

--- a/src/zir/bridge.zig
+++ b/src/zir/bridge.zig
@@ -684,7 +684,7 @@ pub const ZirBridge = struct {
                     extra_index += 1;
                     break :blk captures_len;
                 } else 0;
-                const body_len = if (compat.zir.enumDeclHasTagType(small)) blk: {
+                const body_len = if (compat.zir.enumDeclHasBodyLen(small)) blk: {
                     const body_len = zir.extra[extra_index];
                     extra_index += 1;
                     break :blk body_len;

--- a/src/zir/bridge.zig
+++ b/src/zir/bridge.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const builtin = @import("builtin");
+const compat = @import("../compat.zig");
 const source_mod = @import("../source.zig");
 const type_info_mod = @import("../types/type_info.zig");
 const decls_mod = @import("decls.zig");
@@ -305,10 +307,7 @@ pub const ZirBridge = struct {
         var pending: std.ArrayList(Zir.Inst.Index) = .empty;
         defer pending.deinit(allocator);
 
-        var root_iter = zir.declIterator(.main_struct_inst);
-        while (root_iter.next()) |decl_inst| {
-            pending.append(allocator, decl_inst) catch return null;
-        }
+        compat.zir.appendDecls(allocator, zir, .main_struct_inst, &pending) catch return null;
 
         var contents: Zir.DeclContents = .init;
         defer contents.deinit(allocator);
@@ -325,10 +324,7 @@ pub const ZirBridge = struct {
 
             zir.findTrackable(allocator, &contents, decl_inst) catch return null;
             for (contents.explicit_types.items) |type_inst| {
-                var type_iter = zir.declIterator(type_inst);
-                while (type_iter.next()) |nested_decl| {
-                    pending.append(allocator, nested_decl) catch return null;
-                }
+                compat.zir.appendDecls(allocator, zir, type_inst, &pending) catch return null;
             }
         }
 
@@ -593,7 +589,7 @@ pub const ZirBridge = struct {
                     break :blk decls_len;
                 } else 0;
                 extra_index += captures_len * 2;
-                if (small.has_backing_int) {
+                if (compat.zir.structDeclHasBackingInt(small)) {
                     const backing_int_body_len = zir.extra[extra_index];
                     extra_index += 1;
                     if (backing_int_body_len == 0) {
@@ -656,13 +652,13 @@ pub const ZirBridge = struct {
                 const small: Zir.Inst.UnionDecl.Small = @bitCast(extended.small);
                 const extra = zir.extraData(Zir.Inst.UnionDecl, extended.operand);
                 var extra_index = extra.end;
-                extra_index += @intFromBool(small.has_tag_type);
+                extra_index += @intFromBool(compat.zir.unionDeclHasTagType(small));
                 const captures_len = if (small.has_captures_len) blk: {
                     const captures_len = zir.extra[extra_index];
                     extra_index += 1;
                     break :blk captures_len;
                 } else 0;
-                const body_len = if (small.has_body_len) blk: {
+                const body_len = if (compat.zir.unionDeclHasArgTypeBody(small)) blk: {
                     const body_len = zir.extra[extra_index];
                     extra_index += 1;
                     break :blk body_len;
@@ -682,13 +678,13 @@ pub const ZirBridge = struct {
                 const small: Zir.Inst.EnumDecl.Small = @bitCast(extended.small);
                 const extra = zir.extraData(Zir.Inst.EnumDecl, extended.operand);
                 var extra_index = extra.end;
-                extra_index += @intFromBool(small.has_tag_type);
+                extra_index += @intFromBool(compat.zir.enumDeclHasTagType(small));
                 const captures_len = if (small.has_captures_len) blk: {
                     const captures_len = zir.extra[extra_index];
                     extra_index += 1;
                     break :blk captures_len;
                 } else 0;
-                const body_len = if (small.has_body_len) blk: {
+                const body_len = if (compat.zir.enumDeclHasTagType(small)) blk: {
                     const body_len = zir.extra[extra_index];
                     extra_index += 1;
                     break :blk body_len;
@@ -714,103 +710,14 @@ pub const ZirBridge = struct {
         target_offset: Ast.Node.Offset,
         inst: Zir.Inst.Index,
         defers: *std.AutoHashMapUnmanaged(u32, void),
-        comptime kind: enum { normal, err_union },
+        comptime _: enum { normal, err_union },
     ) ?u32 {
-        const inst_data = zir.instructions.items(.data)[@intFromEnum(inst)].pl_node;
-        const extra = zir.extraData(switch (kind) {
-            .normal => Zir.Inst.SwitchBlock,
-            .err_union => Zir.Inst.SwitchBlockErrUnion,
-        }, inst_data.payload_index);
-
-        var extra_index: usize = extra.end;
-
-        const multi_cases_len = if (extra.data.bits.has_multi_cases) blk: {
-            const len = zir.extra[extra_index];
-            extra_index += 1;
-            break :blk len;
-        } else 0;
-
-        if (switch (kind) {
-            .normal => extra.data.bits.any_has_tag_capture,
-            .err_union => extra.data.bits.any_uses_err_capture,
-        }) {
-            extra_index += 1;
-        }
-
-        const has_special = switch (kind) {
-            .normal => extra.data.bits.special_prongs != .none,
-            .err_union => has_special: {
-                const prong_info: Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
-                extra_index += 1;
-                const body = zir.bodySlice(extra_index, prong_info.body_len);
-                extra_index += body.len;
-                if (findZirInstForNodeInBody(allocator, zir, target_offset, body, defers)) |found| return found;
-                break :has_special extra.data.bits.has_else;
-            },
-        };
-
-        if (has_special) {
-            const has_else = if (kind == .normal)
-                extra.data.bits.special_prongs.hasElse()
-            else
-                true;
-            if (has_else) {
-                const prong_info: Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
-                extra_index += 1;
-                const body = zir.bodySlice(extra_index, prong_info.body_len);
-                extra_index += body.len;
-                if (findZirInstForNodeInBody(allocator, zir, target_offset, body, defers)) |found| return found;
-            }
-            if (kind == .normal) {
-                const special_prongs = extra.data.bits.special_prongs;
-                if (special_prongs.hasUnder()) {
-                    var trailing_items_len: u32 = 0;
-                    if (special_prongs.hasOneAdditionalItem()) {
-                        extra_index += 1;
-                    } else if (special_prongs.hasManyAdditionalItems()) {
-                        const items_len = zir.extra[extra_index];
-                        extra_index += 1;
-                        const ranges_len = zir.extra[extra_index];
-                        extra_index += 1;
-                        trailing_items_len = items_len + ranges_len * 2;
-                    }
-                    const prong_info: Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
-                    extra_index += 1 + trailing_items_len;
-                    const body = zir.bodySlice(extra_index, prong_info.body_len);
-                    extra_index += body.len;
-                    if (findZirInstForNodeInBody(allocator, zir, target_offset, body, defers)) |found| return found;
-                }
-            }
-        }
-
-        {
-            const scalar_cases_len = extra.data.bits.scalar_cases_len;
-            for (0..scalar_cases_len) |_| {
-                extra_index += 1;
-                const prong_info: Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
-                extra_index += 1;
-                const body = zir.bodySlice(extra_index, prong_info.body_len);
-                extra_index += body.len;
-                if (findZirInstForNodeInBody(allocator, zir, target_offset, body, defers)) |found| return found;
-            }
-        }
-
-        for (0..multi_cases_len) |_| {
-            const items_len = zir.extra[extra_index];
-            extra_index += 1;
-            const ranges_len = zir.extra[extra_index];
-            extra_index += 1;
-            const prong_info: Zir.Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
-            extra_index += 1;
-
-            extra_index += items_len + ranges_len * 2;
-
-            const body = zir.bodySlice(extra_index, prong_info.body_len);
-            extra_index += body.len;
-
+        var bodies: std.ArrayList([]const Zir.Inst.Index) = .empty;
+        defer bodies.deinit(allocator);
+        compat.zir.appendSwitchBodies(allocator, zir, inst, &bodies) catch return null;
+        for (bodies.items) |body| {
             if (findZirInstForNodeInBody(allocator, zir, target_offset, body, defers)) |found| return found;
         }
-
         return null;
     }
 
@@ -1012,12 +919,12 @@ pub const ZirBridge = struct {
                 const token = main_tokens[type_node];
                 if (token >= token_tags.len or token_tags[token] != .identifier) return null;
                 const type_name = extractIdentifier(source, token_starts[token]);
-                const builtin = parseBuiltinType(type_name, zir);
+                const builtin_type = parseBuiltinType(type_name, zir);
                 // If not a builtin type, preserve the type name as type_str
-                if (builtin.kind == .unknown) {
+                if (builtin_type.kind == .unknown) {
                     return .{ .kind = .unknown, .type_str = type_name };
                 }
-                return builtin;
+                return builtin_type;
             },
             .error_union => {
                 // Error union type: T!E or anyerror!T
@@ -1212,11 +1119,13 @@ test "ZirBridge parse error handling" {
 test "ZirBridge rejects source with AstGen compile errors" {
     const allocator = std.testing.allocator;
 
-    // `@Int` is a Zig 0.16 builtin; the 0.15.2 frontend parses it fine but
-    // AstGen records "invalid builtin function" inside the Zir instead of
-    // returning an error. Without the hasCompileErrors guard, loadFromSource
-    // would succeed with incomplete type information.
-    const code: [:0]const u8 = "const T = @Int(.signed, 8);";
+    // Each frontend rejects a builtin introduced by the other frontend. The
+    // parser accepts both spellings, so the error is recorded in ZIR and must
+    // be checked explicitly rather than mistaken for valid type information.
+    const code: [:0]const u8 = if (builtin.zig_version.minor == 16)
+        "const T = @Type(.{});"
+    else
+        "const T = @Int(.signed, 8);";
     var source = Source.init(allocator, "test.zig", code);
     defer source.deinit();
 

--- a/test/fixture_runner.zig
+++ b/test/fixture_runner.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const src = @import("src");
+const compat = src.compat;
 const Source = src.Source;
 const Diagnostic = src.Diagnostic;
 const Severity = src.Severity;
@@ -338,24 +339,20 @@ pub fn runCheckerFixturesInDir(
     checker: *const Checker,
     dir_path: []const u8,
 ) !void {
-    var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch |err| {
+    const io_context = compat.defaultContext();
+    var dir = compat.openDir(io_context, dir_path, true) catch |err| {
         std.debug.print("Failed to open fixture directory: {s}: {}\n", .{ dir_path, err });
         return err;
     };
-    defer dir.close();
+    defer compat.closeDir(io_context, &dir);
 
-    var iter = dir.iterate();
-    while (try iter.next()) |entry| {
-        if (entry.kind != .file) continue;
-        if (!std.mem.endsWith(u8, entry.name, ".zig")) continue;
+    while (try compat.nextDir(io_context, &dir)) |entry| {
+        if (entry.kind != .file or !std.mem.endsWith(u8, entry.name, ".zig")) continue;
 
         const fixture_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir_path, entry.name });
         defer allocator.free(fixture_path);
 
-        const file = try dir.openFile(entry.name, .{});
-        defer file.close();
-
-        const content = try file.readToEndAllocOptions(allocator, 1024 * 1024, null, .of(u8), 0);
+        const content = try compat.readFileAlloc(io_context, allocator, fixture_path, 1024 * 1024);
         defer allocator.free(content);
 
         try runCheckerFixture(allocator, checker, fixture_path, content);
@@ -368,24 +365,20 @@ pub fn runFixturesInDir(
     rule: *const Rule,
     dir_path: []const u8,
 ) !void {
-    var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch |err| {
+    const io_context = compat.defaultContext();
+    var dir = compat.openDir(io_context, dir_path, true) catch |err| {
         std.debug.print("Failed to open fixture directory: {s}: {}\n", .{ dir_path, err });
         return err;
     };
-    defer dir.close();
+    defer compat.closeDir(io_context, &dir);
 
-    var iter = dir.iterate();
-    while (try iter.next()) |entry| {
-        if (entry.kind != .file) continue;
-        if (!std.mem.endsWith(u8, entry.name, ".zig")) continue;
+    while (try compat.nextDir(io_context, &dir)) |entry| {
+        if (entry.kind != .file or !std.mem.endsWith(u8, entry.name, ".zig")) continue;
 
         const fixture_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir_path, entry.name });
         defer allocator.free(fixture_path);
 
-        const file = try dir.openFile(entry.name, .{});
-        defer file.close();
-
-        const content = try file.readToEndAllocOptions(allocator, 1024 * 1024, null, .of(u8), 0);
+        const content = try compat.readFileAlloc(io_context, allocator, fixture_path, 1024 * 1024);
         defer allocator.free(content);
 
         try runFixture(allocator, rule, fixture_path, content);


### PR DESCRIPTION
## Issue

Zwanzig embeds Zig's compiler frontend and depends on version-specific standard-library and ZIR APIs. The existing implementation only supported Zig 0.15.2, while frontend mismatches could leave typed analysis incomplete without an explicit failure.

## Solution

Add dual-toolchain support for exact Zig 0.15.2 and 0.16.0 builds. Compile-time selection chooses the appropriate entry point and compatibility adapters for I/O, filesystem operations, concurrency, writers, timestamps, and ZIR decoding while keeping the analyzer, rules, and type models shared.

The build now rejects untested toolchains and AstGen compile errors explicitly, isolates cache entries by embedded frontend version, and reports that frontend in `--version`. Documentation and the development workflow describe the supported matrix.

## Context

This builds on the migration groundwork in [PR #110](https://github.com/forketyfork/zwanzig/pull/110) and follows `docs/ZIG_0_16_MIGRATION_PLAN.md`.

Automated validation passed under both toolchains:

- Zig 0.15.2: `just test`, `just lint`
- Zig 0.16.0: `nix develop .#zig016 -c just test`, `nix develop .#zig016 -c just lint`
