### PR TITLE
test: add Zig frontend fixture matrix

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -173,6 +173,16 @@ fn addFixtureCheck(
 }
 
 fn addFixtureChecks(b: *std.Build, step: *std.Build.Step, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) void {
+    addFixtureCheck(b, step, target, optimize, "test/fixtures/frontend_matrix", "shared.zig");
+    addFixtureCheck(
+        b,
+        step,
+        target,
+        optimize,
+        "test/fixtures/frontend_matrix",
+        if (builtin.zig_version.minor == 16) "zig_0_16.zig" else "zig_0_15.zig",
+    );
+
     const fixture_dirs = [_][]const u8{
         "test/fixtures/empty_catch",
         "test/fixtures/dupe_import",

--- a/docs/ZIG_0_16_MIGRATION_PLAN.md
+++ b/docs/ZIG_0_16_MIGRATION_PLAN.md
@@ -604,16 +604,16 @@ the same diagnostic fields under both builds.
 
 #### Acceptance criteria
 
-- [ ] `nix develop -c just test` passes, including the matching and mismatching
+- [x] `nix develop -c just test` passes, including the matching and mismatching
   frontend assertions.
-- [ ] `nix develop .#zig016 -c just test` passes with the inverse fixture
+- [x] `nix develop .#zig016 -c just test` passes with the inverse fixture
   selection.
-- [ ] `nix develop -c zig build check-fixtures` and the equivalent 0.16 command
+- [x] `nix develop -c zig build check-fixtures` and the equivalent 0.16 command
   produce the same baseline failures recorded in
   `docs/internal/ZIG_0_16_INVENTORY.md` (15 at the time of writing) and no new
   failures; the newly added matching fixtures compile successfully. The
   baseline failures remain visible and are not silently filtered.
-- [ ] The shared fixture produces identical expected diagnostic fields in both
+- [x] The shared fixture produces identical expected diagnostic fields in both
   toolchains, and `nix develop -c zig fmt --check test/fixtures/frontend_matrix`
   passes (the canonical 0.15.2 formatter parses the 0.16 fixture too — `@Int`
   fails only at AstGen, not at parse).

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -24,6 +24,17 @@ comptime {
     }
 }
 
+pub const Frontend = enum {
+    zig_0_15,
+    zig_0_16,
+};
+
+pub const frontend: Frontend = switch (builtin.zig_version.minor) {
+    15 => .zig_0_15,
+    16 => .zig_0_16,
+    else => unreachable,
+};
+
 pub const io = if (builtin.zig_version.minor == 16)
     @import("compat/zig_0_16/io.zig")
 else

--- a/test/fixture_tests.zig
+++ b/test/fixture_tests.zig
@@ -5,6 +5,7 @@ const runCheckerFixturesInDir = fixture_runner.runCheckerFixturesInDir;
 
 // Import all rules from the src module
 const src = @import("src");
+const compat = src.compat;
 const DupeImportRule = src.rules.dupe_import.DupeImportRule;
 const TodoCommentRule = src.rules.todo_comment.TodoCommentRule;
 const EmptyErrdeferRule = src.rules.empty_errdefer.EmptyErrdeferRule;
@@ -24,6 +25,53 @@ const StoreViolationsEngineChecker = src.checkers.store_violations_engine.StoreV
 const StackEscapeEngineChecker = src.checkers.stack_escape_engine.StackEscapeEngineChecker;
 const DivideByZeroEngineChecker = src.checkers.divide_by_zero_engine.DivideByZeroEngineChecker;
 const SliceBoundsEngineChecker = src.checkers.slice_bounds_engine.SliceBoundsEngineChecker;
+
+fn frontendFixtureName(frontend: compat.Frontend) []const u8 {
+    return switch (frontend) {
+        .zig_0_15 => "zig_0_15.zig",
+        .zig_0_16 => "zig_0_16.zig",
+    };
+}
+
+fn runFrontendTypeInfoFixture(
+    allocator: std.mem.Allocator,
+    fixture_name: []const u8,
+    expected_type_info: bool,
+) !void {
+    const io_context = compat.defaultContext();
+    const fixture_path = try std.fmt.allocPrint(allocator, "test/fixtures/frontend_matrix/{s}", .{fixture_name});
+    defer allocator.free(fixture_path);
+
+    const content = try compat.readFileAlloc(io_context, allocator, fixture_path, 1024 * 1024);
+    defer allocator.free(content);
+
+    var source = src.Source.init(allocator, fixture_path, content);
+    defer source.deinit();
+
+    try std.testing.expectEqual(expected_type_info, source.hasTypeInfo());
+}
+
+test "frontend matrix preserves shared rule diagnostics" {
+    const allocator = std.testing.allocator;
+    const io_context = compat.defaultContext();
+    const fixture_path = "test/fixtures/frontend_matrix/shared.zig";
+    const content = try compat.readFileAlloc(io_context, allocator, fixture_path, 1024 * 1024);
+    defer allocator.free(content);
+
+    try fixture_runner.runFixture(allocator, &TodoCommentRule.rule, fixture_path, content);
+}
+
+test "frontend matrix provides type information only for the matching frontend" {
+    const allocator = std.testing.allocator;
+    const matching_fixture = frontendFixtureName(compat.frontend);
+    const mismatching_fixture = frontendFixtureName(switch (compat.frontend) {
+        .zig_0_15 => .zig_0_16,
+        .zig_0_16 => .zig_0_15,
+    });
+
+    try runFrontendTypeInfoFixture(allocator, matching_fixture, true);
+    try runFrontendTypeInfoFixture(allocator, mismatching_fixture, false);
+}
 
 test "dupe_import fixtures" {
     try runFixturesInDir(std.testing.allocator, &DupeImportRule.rule, "test/fixtures/dupe_import");

--- a/test/fixtures/frontend_matrix/shared.zig
+++ b/test/fixtures/frontend_matrix/shared.zig
@@ -1,0 +1,4 @@
+// EXPECT: line=3 rule=todo message=keep diagnostic parity
+const shared_value: u8 = 1;
+// TODO: keep diagnostic parity
+const another_shared_value: u8 = shared_value + 1;

--- a/test/fixtures/frontend_matrix/zig_0_15.zig
+++ b/test/fixtures/frontend_matrix/zig_0_15.zig
@@ -1,0 +1,1 @@
+const T = @Type(.{ .int = .{ .signedness = .signed, .bits = 8 } });

--- a/test/fixtures/frontend_matrix/zig_0_16.zig
+++ b/test/fixtures/frontend_matrix/zig_0_16.zig
@@ -1,0 +1,1 @@
+const T = @Int(.signed, 8);


### PR DESCRIPTION
## Issue

The Zig 0.16 migration needs an explicit fixture matrix proving that shared-syntax diagnostics remain stable while typed analysis is available only when the embedded frontend matches the fixture's Zig version.

## Solution

Add shared, Zig 0.15.2-specific, and Zig 0.16.0-specific fixtures. The fixture tests select the matching frontend through the compatibility layer, load both version-specific files, and assert the expected `Source.hasTypeInfo()` behavior. The shared fixture is checked through the existing `todo` rule with exact diagnostic expectations.

The build's fixture-compilation step checks the shared fixture and only the version-specific fixture supported by the active compiler, preserving the intentionally incompatible fixture for runtime mismatch coverage.

## Context

This implements Task 8 of `docs/ZIG_0_16_MIGRATION_PLAN.md` and records its completed acceptance criteria. The existing 15 fixture-compilation failures remain unchanged under both supported toolchains and are documented in `docs/internal/ZIG_0_16_INVENTORY.md`.
