### PR TITLE
ci: test both embedded Zig frontends

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,18 @@ jobs:
   build-matrix:
     needs: changes
     if: needs.changes.outputs.code == 'true'
+    name: build (${{ matrix.zig_version }})
     runs-on: ubuntu-latest
+    # Zig 0.15.2 is the canonical formatter and SARIF producer; both legs
+    # still run the complete `just ci` suite against their embedded frontend.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - zig_version: '0.15.2'
+            nix_flake: '.'
+          - zig_version: '0.16.0'
+            nix_flake: '.#zig016'
     env:
       ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/zwanzig/.zig-cache
       ZIG_LOCAL_CACHE_DIR: ${{ github.workspace }}/zwanzig/.zig-cache/local
@@ -69,9 +80,17 @@ jobs:
         uses: actions/cache@v6
         with:
           path: zwanzig/.zig-cache
-          key: zig-${{ runner.os }}-${{ hashFiles('zwanzig/build.zig', 'zwanzig/build.zig.zon', 'zwanzig/src/**', 'zwanzig/test/**', 'zwanzig/flake.lock') }}
+          key: >-
+            zig-${{ runner.os }}-${{ matrix.zig_version }}-${{
+            hashFiles(
+              'zwanzig/build.zig',
+              'zwanzig/build.zig.zon',
+              'zwanzig/src/**',
+              'zwanzig/test/**',
+              'zwanzig/flake.lock'
+            ) }}
           restore-keys: |
-            zig-${{ runner.os }}-
+            zig-${{ runner.os }}-${{ matrix.zig_version }}-
 
       - name: Cache Nix store
         uses: cachix/cachix-action@v17
@@ -82,14 +101,15 @@ jobs:
       - name: Build, test, lint
         run: |
           for i in 1 2 3; do
-            nix develop --accept-flake-config --command just ci && break
+            nix develop "${{ matrix.nix_flake }}" \
+              --accept-flake-config --command just ci && break
             if [ $i -eq 3 ]; then exit 1; fi
             sleep 5
           done
         working-directory: zwanzig
 
       - name: Upload SARIF results
-        if: always()
+        if: always() && matrix.zig_version == '0.15.2'
         uses: github/codeql-action/upload-sarif@v4.37.7
         with:
           sarif_file: zwanzig/results.sarif
@@ -102,7 +122,8 @@ jobs:
     steps:
       - name: Check result
         run: |
-          if [[ "${{ needs.documentation-versions.result }}" != "success" ]]; then
+          documentation_result="${{ needs.documentation-versions.result }}"
+          if [[ "$documentation_result" != "success" ]]; then
             echo "Documentation version check failed"
             exit 1
           fi

--- a/docs/ZIG_0_16_MIGRATION_PLAN.md
+++ b/docs/ZIG_0_16_MIGRATION_PLAN.md
@@ -653,13 +653,13 @@ one canonical Code Scanning upload.
 
 #### Acceptance criteria
 
-- [ ] A code-changing pull request shows two build legs, one for each pinned
+- [x] A code-changing pull request shows two build legs, one for each pinned
   frontend, and the aggregate job fails if either leg fails.
-- [ ] Both legs execute `just test` and `just lint`; the canonical leg uploads
+- [x] Both legs execute `just test` and `just lint`; the canonical leg uploads
   exactly one SARIF file.
-- [ ] The cache key contains the frontend identity and no 0.15.2 cache path is
+- [x] The cache key contains the frontend identity and no 0.15.2 cache path is
   restored for a 0.16.0 job.
-- [ ] The workflow YAML remains valid, and the local equivalents
+- [x] The workflow YAML remains valid, and the local equivalents
   `nix develop -c just ci` and `nix develop .#zig016 -c just ci` pass.
 
 ---


### PR DESCRIPTION
## Issue

The build workflow validated only the Zig 0.15.2 frontend, so changes could regress the Zig 0.16.0 frontend without CI detecting it. The shared build cache and SARIF upload also had no frontend-specific ownership.

## Solution

The build job now runs a fail-fast-disabled matrix for the pinned Zig 0.15.2 and 0.16.0 Nix shells. Cache keys and restore prefixes include the frontend version, and both legs run the complete `just ci` suite. The 0.15.2 leg remains the canonical SARIF producer to avoid duplicate Code Scanning findings.

## Context

This implements Task 9 of `docs/ZIG_0_16_MIGRATION_PLAN.md`, following the frontend fixture matrix and compatibility work already present on `main`.
