### PR TITLE
ci: publish dual-frontend release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,26 @@ jobs:
           $archive = "${{ steps.archive_name.outputs.name }}"
           Compress-Archive -Path dist/* -DestinationPath $archive
 
+      - name: Upload packaged artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.zig_version }}-${{ matrix.asset_suffix }}
+          path: ${{ steps.archive_name.outputs.name }}
+          if-no-files-found: error
+
+  publish:
+    name: Publish release assets
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: dist
+          merge-multiple: true
+
       - name: Upload release assets
         uses: softprops/action-gh-release@v3.0.2
         with:
-          files: ${{ steps.archive_name.outputs.name }}
+          files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
+---
 name: Release
 
-on:
+'on':
   push:
     tags:
       - "v*"
@@ -10,14 +11,21 @@ permissions:
 
 jobs:
   validate:
+    name: validate (${{ matrix.zig_version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        zig_version:
+          - '0.15.2'
+          - '0.16.0'
     steps:
       - uses: actions/checkout@v7
 
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: ${{ matrix.zig_version }}
 
       - name: Run release checks
         run: ./scripts/release-check.sh "${{ github.ref_name }}"
@@ -30,12 +38,27 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            zig_version: '0.15.2'
             asset_suffix: linux-x86_64
             archive_ext: tar.gz
           - os: macos-latest
+            zig_version: '0.15.2'
             asset_suffix: macos-aarch64
             archive_ext: tar.gz
           - os: windows-latest
+            zig_version: '0.15.2'
+            asset_suffix: windows-x86_64
+            archive_ext: zip
+          - os: ubuntu-latest
+            zig_version: '0.16.0'
+            asset_suffix: linux-x86_64
+            archive_ext: tar.gz
+          - os: macos-latest
+            zig_version: '0.16.0'
+            asset_suffix: macos-aarch64
+            archive_ext: tar.gz
+          - os: windows-latest
+            zig_version: '0.16.0'
             asset_suffix: windows-x86_64
             archive_ext: zip
 
@@ -45,10 +68,19 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: ${{ matrix.zig_version }}
 
       - name: Build release binary
         run: zig build -Doptimize=ReleaseFast
+
+      - name: Set archive name
+        id: archive_name
+        shell: bash
+        run: |
+          archive="zwanzig-${{ github.ref_name }}-zig-${{ matrix.zig_version }}"
+          archive="${archive}-${{ matrix.asset_suffix }}"
+          archive="${archive}.${{ matrix.archive_ext }}"
+          echo "name=$archive" >> "$GITHUB_OUTPUT"
 
       - name: Package artifact (Unix)
         if: runner.os != 'Windows'
@@ -56,7 +88,7 @@ jobs:
           mkdir -p dist
           cp zig-out/bin/zwanzig dist/
           cp LICENSE README.md dist/
-          tar -czf "zwanzig-${{ github.ref_name }}-${{ matrix.asset_suffix }}.${{ matrix.archive_ext }}" -C dist .
+          tar -czf "${{ steps.archive_name.outputs.name }}" -C dist .
 
       - name: Package artifact (Windows)
         if: runner.os == 'Windows'
@@ -65,9 +97,10 @@ jobs:
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           Copy-Item zig-out/bin/zwanzig.exe dist/
           Copy-Item LICENSE, README.md dist/
-          Compress-Archive -Path dist/* -DestinationPath "zwanzig-${{ github.ref_name }}-${{ matrix.asset_suffix }}.${{ matrix.archive_ext }}"
+          $archive = "${{ steps.archive_name.outputs.name }}"
+          Compress-Archive -Path dist/* -DestinationPath $archive
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v3.0.2
         with:
-          files: zwanzig-${{ github.ref_name }}-${{ matrix.asset_suffix }}.${{ matrix.archive_ext }}
+          files: ${{ steps.archive_name.outputs.name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--version` now reports the embedded Zig frontend version. (PR #109)
 - A reproducible Zig 0.16.0 development shell and migration compatibility inventory are now available. (PR #110)
 - Source builds now support both Zig 0.15.2 and Zig 0.16.0 frontends, with the selected frontend reported by `--version`. (PR #111; follow-up to PR #110)
+- Release archives are now published for both Zig 0.15.2 and Zig 0.16.0 frontends, with the frontend version included in each asset name. (PR #115)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ Zwanzig is a static analyzer and linter for Zig code, combining fast AST/token r
 
 Download the archive for your platform from the [latest release](https://github.com/forketyfork/zwanzig/releases/latest):
 
-| Platform | Archive |
-| --- | --- |
-| Linux x86_64 | `zwanzig-vX.Y.Z-linux-x86_64.tar.gz` |
-| macOS ARM64 | `zwanzig-vX.Y.Z-macos-aarch64.tar.gz` |
-| Windows x86_64 | `zwanzig-vX.Y.Z-windows-x86_64.zip` |
+| Platform | Embedded frontend | Archive |
+| --- | --- | --- |
+| Linux x86_64 | Zig 0.15.2 | `zwanzig-vX.Y.Z-zig-0.15.2-linux-x86_64.tar.gz` |
+| Linux x86_64 | Zig 0.16.0 | `zwanzig-vX.Y.Z-zig-0.16.0-linux-x86_64.tar.gz` |
+| macOS ARM64 | Zig 0.15.2 | `zwanzig-vX.Y.Z-zig-0.15.2-macos-aarch64.tar.gz` |
+| macOS ARM64 | Zig 0.16.0 | `zwanzig-vX.Y.Z-zig-0.16.0-macos-aarch64.tar.gz` |
+| Windows x86_64 | Zig 0.15.2 | `zwanzig-vX.Y.Z-zig-0.15.2-windows-x86_64.zip` |
+| Windows x86_64 | Zig 0.16.0 | `zwanzig-vX.Y.Z-zig-0.16.0-windows-x86_64.zip` |
 
 Extract the archive and either add its directory to `PATH` or invoke the executable directly:
 
@@ -28,7 +31,19 @@ On Windows, run `.\zwanzig.exe src\` instead.
 
 ### Zig frontend compatibility
 
-Zwanzig embeds the Zig frontend used to build it. Source builds support Zig 0.15.2 and Zig 0.16.0, and select the matching compatibility layer automatically. Run `zwanzig --version` to see which frontend a binary contains; use a binary built with the frontend version that matches the Zig language version used by your project.
+Zwanzig embeds the Zig frontend used to build it. Source builds support Zig 0.15.2 and Zig 0.16.0, and select the matching compatibility layer automatically. Release archive names include the embedded frontend version, so choose the `zig-0.15.2` archive for a Zig 0.15.2 project and the `zig-0.16.0` archive for a Zig 0.16.0 project. Run `zwanzig --version` to verify which frontend a binary contains.
+
+To build from source with the 0.15.2 frontend, use the default shell:
+
+```bash
+nix develop -c just build
+```
+
+To build with the 0.16.0 frontend, select the migration shell:
+
+```bash
+nix develop .#zig016 -c just build
+```
 
 ### Zig build dependency
 
@@ -62,7 +77,7 @@ zig build lint
 
 ### GitHub Actions (SARIF)
 
-Download a pinned release binary before running Zwanzig. The Linux runner is x86_64, so it uses the Linux x86_64 archive:
+Download a pinned release binary before running Zwanzig. The example selects the Zig 0.15.2 frontend; set `ZWANZIG_ZIG_FRONTEND` to `0.16.0` for a Zig 0.16.0 project. The Linux runner is x86_64, so it uses the Linux x86_64 archive:
 
 ```yaml
 name: Zwanzig
@@ -77,6 +92,7 @@ permissions:
 
 env:
   ZWANZIG_VERSION: v0.14.0
+  ZWANZIG_ZIG_FRONTEND: 0.15.2
 
 jobs:
   analyze:
@@ -86,7 +102,7 @@ jobs:
 
       - name: Install Zwanzig
         run: |
-          archive="zwanzig-${ZWANZIG_VERSION}-linux-x86_64.tar.gz"
+          archive="zwanzig-${ZWANZIG_VERSION}-zig-${ZWANZIG_ZIG_FRONTEND}-linux-x86_64.tar.gz"
           curl --fail --location --silent --show-error \
             "https://github.com/forketyfork/zwanzig/releases/download/${ZWANZIG_VERSION}/${archive}" \
             --output "${RUNNER_TEMP}/${archive}"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,6 +6,18 @@
 zig build
 ```
 
+For a reproducible source build with the Zig 0.15.2 frontend, use the default development shell:
+
+```bash
+nix develop -c just build
+```
+
+To build with the Zig 0.16.0 frontend, select the dedicated shell:
+
+```bash
+nix develop .#zig016 -c just build
+```
+
 ## Run the CLI
 
 If `zwanzig` is on your PATH:
@@ -28,7 +40,7 @@ zwanzig --version
 
 ### Zig frontend compatibility
 
-Zwanzig embeds the Zig frontend used to build it, so frontend-specific syntax is interpreted according to that embedded version. Source builds support exactly Zig 0.15.2 and Zig 0.16.0. The selected frontend is included in `--version`; when analyzing code that uses version-specific language features, use a Zwanzig binary built with the matching frontend.
+Zwanzig embeds the Zig frontend used to build it, so frontend-specific syntax is interpreted according to that embedded version. Source builds support exactly Zig 0.15.2 and Zig 0.16.0. Release archive names include the selected frontend: use an archive containing `zig-0.15.2` for a Zig 0.15.2 project and one containing `zig-0.16.0` for a Zig 0.16.0 project. The selected frontend is also included in `--version`; when analyzing code that uses version-specific language features, use a Zwanzig binary built with the matching frontend.
 
 ### Files and directories
 


### PR DESCRIPTION
## Issue

The release workflow published only one binary per platform, so users could not select an artifact containing the Zig frontend matching their project.

## Solution

Validate releases with both supported Zig frontends and build the complete platform/frontend matrix before uploading artifacts.
Encode the frontend version in every archive name and document the selection rules for release binaries, GitHub Actions, and source builds.

## Context

This implements Task 10 of `docs/ZIG_0_16_MIGRATION_PLAN.md`. The launcher remains deferred; artifact names and `--version` provide explicit frontend selection.
