### PR TITLE
docs: close Zig 0.16 migration decisions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,9 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     name: build (${{ matrix.zig_version }})
     runs-on: ubuntu-latest
-    # Zig 0.15.2 is the canonical formatter and SARIF producer; both legs
-    # still run the complete `just ci` suite against their embedded frontend.
+    # Zig 0.15.2 is the sole canonical formatter and SARIF producer. `just
+    # lint` checks formatting in that leg; the 0.16.0 leg runs the remaining
+    # lint checks against its embedded frontend.
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - README installation instructions now cover release binaries, Zig build dependencies, and GitHub Actions usage. (PR #103)
+- Dual-frontend release artifacts are maintained through v0.17.x; v0.18.0 is planned as the first release without a Zig 0.15.2 artifact. (PR #116)
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ Zwanzig is a static analyzer and linter for Zig. It uses a modular rule-based ar
 zig build              # Build the project
 zig build test         # Run all tests
 zig build run -- <files>  # Run analyzer on files
-zig fmt src            # Format code
-zig fmt --check src/   # Check formatting (lint)
+zig fmt src            # Format code with the canonical Zig 0.15.2 shell
+zig fmt --check src/   # Check canonical formatting
 ```
 
 With `just` (recommended):
@@ -39,7 +39,9 @@ For any code changes, run both tests and linting:
 
 All new rules/checkers must have test fixtures.
 
-All code must be formatted with `zig fmt`.
+All code must be formatted with `zig fmt` from Zig 0.15.2, which is the
+project's sole canonical formatter. The Zig 0.16.0 shell is used to validate
+the alternate embedded frontend; its formatter output is not authoritative.
 
 Any changes or additions to the existing rules/checkers must be documented.
 
@@ -141,7 +143,7 @@ zig build run -- test/fixtures/store_violations_engine/fixture_name.zig
 
 ## Code Style
 
-- Zig standard formatting via `zig fmt`
+- Zig standard formatting via Zig 0.15.2's `zig fmt` (the canonical formatter)
 - Tests colocated with implementation in the same file
 - Rules in `src/rules/` directory, one file per rule
 - **ArrayList initialization**: In Zig 0.15.2, use `.empty` to initialize ArrayLists (e.g., `var list: std.ArrayList(T) = .empty;`). The allocator is passed to methods like `append(allocator, item)` and `deinit(allocator)`. Do NOT use the old `.init(allocator)` pattern.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Document what your rule checks, why it matters, and show before/after examples.
 
 ## Code style
 
-- Run `zig fmt` before committing
+- Run `nix develop -c just fmt` before committing
 - Write self-documenting code; use comments sparingly
 - Keep functions small and focused
 
@@ -120,7 +120,7 @@ For any user-visible change, add a short entry to the `## [Unreleased]` section 
 1. Fork the repo
 2. Create a branch (`git checkout -b feature/my-rule`)
 3. Make changes
-4. Run `zig build test` and `zig fmt src/`
+4. Run `nix develop -c just test` and `nix develop -c just fmt`
 5. Update `CHANGELOG.md` if your change is user-visible
 6. Commit with a clear message
 7. Open a PR

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ On Windows, run `.\zwanzig.exe src\` instead.
 
 Zwanzig embeds the Zig frontend used to build it. Source builds support Zig 0.15.2 and Zig 0.16.0, and select the matching compatibility layer automatically. Release archive names include the embedded frontend version, so choose the `zig-0.15.2` archive for a Zig 0.15.2 project and the `zig-0.16.0` archive for a Zig 0.16.0 project. Run `zwanzig --version` to verify which frontend a binary contains.
 
+The two frontend artifacts are maintained through the v0.17.x release line.
+v0.18.0 is the first planned release without a Zig 0.15.2 artifact; users on
+Zig 0.15.2 should stay on the latest v0.17.x release.
+
 To build from source with the 0.15.2 frontend, use the default shell:
 
 ```bash

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,6 +16,20 @@ nix develop .#zig016
 
 Run `just test` and `just lint` in both shells when changing code that touches the embedded frontend or its compatibility adapters.
 
+## Formatting
+
+Zig 0.15.2 is the sole canonical formatter. Format and check source files
+from the default shell:
+
+```bash
+nix develop -c zig fmt src
+nix develop -c zig fmt --check src/
+```
+
+The Zig 0.16.0 shell validates the alternate frontend but does not establish
+a competing formatting baseline. Accordingly, `just lint` checks formatting
+in the 0.15.2 shell and runs the remaining lint checks in the 0.16.0 shell.
+
 ## macOS SDK workaround
 
 On macOS 26.x hosts the active `MacOSX.sdk/usr/lib/libSystem.tbd` only advertises `arm64e-macos`, so Zig 0.15.2 cannot link the build runner and emits a long list of undefined libSystem symbols (`__availability_version_check`, `_realpath$DARWIN_EXTSN`, etc.). Upstream tracker: <https://codeberg.org/ziglang/zig/issues/31756>.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -15,3 +15,14 @@
    ```
 
 4. Tag and publish the release from the checked commit.
+
+## Frontend artifacts
+
+The release workflow builds one archive per supported platform for each
+embedded frontend: Zig 0.15.2 and Zig 0.16.0. The frontend is part of every
+archive name (`zig-0.15.2` or `zig-0.16.0`), and the workflow validates both
+frontends before publishing any assets.
+
+The Zig 0.15.2 artifact is maintained through v0.17.x. v0.18.0 is the first
+planned release that drops it; users who still analyze Zig 0.15.2 projects
+should remain on the latest v0.17.x release.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -42,6 +42,10 @@ zwanzig --version
 
 Zwanzig embeds the Zig frontend used to build it, so frontend-specific syntax is interpreted according to that embedded version. Source builds support exactly Zig 0.15.2 and Zig 0.16.0. Release archive names include the selected frontend: use an archive containing `zig-0.15.2` for a Zig 0.15.2 project and one containing `zig-0.16.0` for a Zig 0.16.0 project. The selected frontend is also included in `--version`; when analyzing code that uses version-specific language features, use a Zwanzig binary built with the matching frontend.
 
+Both frontend artifacts are maintained through the v0.17.x release line.
+v0.18.0 is the first planned release without a Zig 0.15.2 artifact; users on
+Zig 0.15.2 should stay on the latest v0.17.x release.
+
 ### Files and directories
 
 ```bash

--- a/docs/ZIG_0_16_MIGRATION_PLAN.md
+++ b/docs/ZIG_0_16_MIGRATION_PLAN.md
@@ -14,7 +14,7 @@
 
 - Default dev toolchain stays **exactly Zig 0.15.2** (`flake.nix` devShell `default`); `build.zig.zon` keeps `.minimum_zig_version = "0.15.2"`. The upper/exact support boundary is enforced by `src/compat.zig`, not by `build.zig.zon`.
 - Every task ends with `just test` and `just lint` green under the default (0.15.2) shell. `just lint` runs zwanzig on its own source.
-- All code formatted with `zig fmt` (0.15.2 is the canonical formatter unless the canonical-formatter decision in Task 7's "Review decisions required" section changes it).
+- All code formatted with `zig fmt` from Zig 0.15.2, the sole canonical formatter; the 0.16.0 CI leg validates the remaining lint checks and analyzer behavior.
 - ArrayList init uses `.empty`, allocator passed to methods (Zig 0.15.2 style, see CLAUDE.md).
 - No silent degradation: a frontend/language mismatch must produce an explicit failure, never incomplete type information (project rule: no speculative fallbacks).
 - User-visible changes get a `CHANGELOG.md` entry under `## [Unreleased]`.
@@ -473,10 +473,10 @@ git commit -m "docs: add Zig 0.16 migration breakage inventory"
 
 ### Task 7 (checkpoint): Expand Phases 2–4 into a detailed plan
 
-**Status: draft awaiting review.** The compat implementation is already present
-on `main` from the work covered by Tasks 1–6. The remaining work is deliberately
-specified below, but must not be started until the open policy decisions are
-reviewed.
+**Status: reviewed and closed.** The compat implementation is present on
+`main` from the work covered by Tasks 1–6. Tasks 8 and 9 are complete. Task 10's
+dual-frontend release workflow and documentation are implemented; its criteria
+that require an actual release tag remain open until that release is run.
 
 #### Status quo
 
@@ -488,15 +488,12 @@ reviewed.
   macOS SDK workaround and that the 15 `check-fixtures` failures are pre-existing
   on both toolchains.
 - The shared fixture suite, cache behavior, executor test, and `just test` /
-  `just lint` checks have already passed in both shells, but there is no
-  dedicated fixture proving matching and mismatching frontend syntax.
-- `.github/workflows/build.yml` runs only `nix develop` (Zig 0.15.2), and
-  `.github/workflows/release.yml` creates one 0.15.2 artifact per platform.
-  `README.md` and `docs/USAGE.md` each already have a "Zig frontend
-  compatibility" section explaining that a binary must match the project's Zig
-  version, and `README.md` has a one-archive-per-platform download table — but
-  the release asset names contain no frontend identity, so the guidance cannot
-  yet point at a concrete artifact.
+  `just lint` checks have passed in both shells, and the fixture matrix proves
+  matching and mismatching frontend syntax.
+- `.github/workflows/build.yml` tests both pinned frontends, and
+  `.github/workflows/release.yml` builds one named artifact per platform and
+  frontend. `README.md` and `docs/USAGE.md` identify the matching artifact;
+  release-tag verification is still pending.
 
 #### Objectives
 
@@ -507,27 +504,27 @@ Complete the migration's remaining user-facing contract:
 2. exercise both shells on every code change;
 3. publish independently selectable 0.15.2 and 0.16.0 binaries for every
    supported platform; and
-4. record the support-lifetime, formatting, and launcher decisions before the
-   release workflow is changed.
+4. record the support-lifetime, formatting, and launcher decisions and keep
+   them aligned with the release workflow and contributor documentation.
 
-#### Review decisions required
+#### Review decisions (adopted)
 
-1. **0.15.2 support lifetime:** keep 0.15.2 artifacts indefinitely, or announce
-   a fixed sunset (the existing proposal is two releases after 0.16 support
-   ships). A sunset reduces release and CI cost but creates a migration deadline
-   for users with 0.15 projects.
-2. **Canonical formatter:** retain Zig 0.15.2 as the sole `zig fmt --check`
-   authority, or switch to 0.16.0. The choice determines whether the second
-   CI leg checks formatting or only runs tests and the analyzer lint.
-3. **Launcher:** keep frontend selection explicit in the artifact name and
-   documentation, or add a launcher that detects the project frontend. The
-   launcher is deferred by default because detection and distribution add a
-   separate compatibility surface; it should be revisited only if user demand
-   shows that filename selection is insufficient.
+1. **0.15.2 support lifetime:** retain both frontend artifacts through the
+   v0.17.x release line, and make v0.18.0 the first release without a 0.15.2
+   artifact. With the current v0.14.0 package as the baseline, this gives the
+   first dual-frontend release and two subsequent release lines for migration.
+   A fixed sunset limits the ongoing release and CI matrix while giving users a
+   specific compatibility window.
+2. **Canonical formatter:** keep Zig 0.15.2 as the sole `zig fmt --check`
+   authority. The 0.16.0 CI leg still runs `just lint`, but its formatter check
+   is skipped so formatter differences cannot redefine the repository baseline.
+   This keeps formatting stable while both frontends are supported.
+3. **Launcher:** defer a frontend-detecting launcher. Artifact names and the
+   usage documentation select the frontend explicitly, avoiding another
+   compatibility and distribution surface. Create a separate launcher plan
+   only if user demand shows that filename selection is insufficient.
 
-Unless the review changes them, the implementation slices below use the
-existing proposal: retain both frontends for two subsequent releases, keep
-0.15.2 canonical for formatting, and defer a launcher.
+These decisions close the policy review for the remaining migration work.
 
 Tasks 8–11 below are the expansion this checkpoint produces. Their acceptance
 criteria use checkbox (`- [ ]`) syntax and are the tracking unit for the
@@ -642,10 +639,10 @@ one canonical Code Scanning upload.
   changes do not spend two build slots.
 - Include the frontend in the Zig cache key. A cache created by one compiler
   must not be reused by the other compiler even when the source hash is equal.
-- Invoke `just ci` in both matrix legs. If the canonical formatter decision
-  (Task 7, "Review decisions required") keeps 0.15.2 authoritative, make that
-  policy explicit in the workflow or Justfile rather than allowing a formatter
-  mismatch to become an unexplained 0.16 failure.
+- Invoke `just ci` in both matrix legs. Task 7 keeps 0.15.2 authoritative for
+  formatting, so the workflow and Justfile must make that policy explicit
+  rather than allowing a formatter mismatch to become an unexplained 0.16
+  failure.
 - Upload SARIF from one designated frontend (the canonical 0.15.2 leg) to avoid
   duplicate findings in GitHub Code Scanning; both legs still run analyzer lint.
 - Keep the aggregate `build` job's result checks correct when either matrix leg
@@ -668,10 +665,10 @@ one canonical Code Scanning upload.
 
 #### Status quo
 
-`.github/workflows/release.yml` validates and builds only with Zig 0.15.2. Its
-platform matrix covers Linux x86_64, macOS aarch64, and Windows x86_64, but the
-asset name contains no frontend identity, so a future 0.16.0 binary would be
-indistinguishable from the existing artifact.
+`.github/workflows/release.yml` validates and builds both Zig 0.15.2 and Zig
+0.16.0. Its platform matrix covers Linux x86_64, macOS aarch64, and Windows
+x86_64, and the asset name includes the embedded frontend. The workflow has not
+yet been exercised by an actual release tag on this migration branch.
 
 #### Objectives
 
@@ -710,7 +707,7 @@ make the embedded language frontend unambiguous before download.
   filename, and the 0.15.2 and 0.16.0 artifacts do not overwrite one another.
 - [ ] Both release validation legs pass `scripts/release-check.sh` before
   upload.
-- [ ] README and usage instructions let a user choose the correct binary
+- [x] README and usage instructions let a user choose the correct binary
   without reading the workflow source.
 
 ---
@@ -719,12 +716,11 @@ make the embedded language frontend unambiguous before download.
 
 #### Status quo
 
-Tasks 1–7 are complete and checked off above; Tasks 8–10 (fixture matrix,
-dual-frontend CI, dual-frontend releases) are specified but not yet
-implemented. The 0.15.2 sunset, canonical formatter, and launcher policies
-remain open — the options, rationales, and the default proposal live in
-Task 7's "Review decisions required" section, which is the single place they
-are argued.
+Tasks 1–9 are complete and checked off above. Task 10's dual-frontend release
+workflow, artifact naming, and user documentation are implemented, while the
+criteria requiring a real release tag remain open. Task 7's support lifetime,
+canonical formatter, and launcher decisions are now adopted and recorded in
+its "Review decisions (adopted)" section.
 
 #### Objectives
 
@@ -742,17 +738,17 @@ actually passed.
   (which currently states no formatter policy), and the CI workflow so
   contributors know which `zig fmt` output is expected.
 - If the launcher remains deferred, retain explicit artifact names and record
-  the closing rationale in Task 7's "Review decisions required" section rather
+  the closing rationale in Task 7's "Review decisions (adopted)" section rather
   than restating it elsewhere; per that section, a launcher becomes a separate
   plan only if user demand shows filename selection is insufficient.
 
 #### Acceptance criteria
 
-- [ ] The three decisions have a durable record with rationale and no
+- [x] The three decisions have a durable record with rationale and no
   contradictory statements in `README.md`, `docs/USAGE.md`, `CLAUDE.md`, or
   `docs/DEVELOPMENT.md`.
-- [ ] The checkboxes in this plan — the Task 1–7 steps and the Task 8–11
+- [x] The checkboxes in this plan — the Task 1–7 steps and the Task 8–11
   acceptance criteria — match the code, CI, and release workflow that actually
   shipped.
-- [ ] The final implementation run ends with `just test` and `just lint` under
+- [x] The final implementation run ends with `just test` and `just lint` under
   both pinned shells.

--- a/justfile
+++ b/justfile
@@ -14,6 +14,14 @@ run-release:
     zig build run -Doptimize=ReleaseFast
 
 fmt:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    zig_version="$(zig version)"
+    if [ "$zig_version" != "0.15.2" ]; then
+        echo "zig fmt is canonical under Zig 0.15.2; use 'nix develop -c just fmt'" >&2
+        exit 1
+    fi
     zig fmt src
 
 lint:
@@ -27,7 +35,18 @@ lint:
     shellcheck scripts/*.sh
     ./scripts/check-doc-versions.sh
 
-    zig fmt --check src/
+    zig_version="$(zig version)"
+    case "$zig_version" in
+        0.15.2)
+            zig fmt --check src/
+            ;;
+        0.16.0)
+            ;;
+        *)
+            echo "unsupported Zig formatter version: $zig_version" >&2
+            exit 1
+            ;;
+    esac
 
     if [ -n "${CI:-}" ]; then
         zig build run -- --use-widening --format sarif src/**/*.zig > results.sarif || true

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -31,7 +31,18 @@ else
     echo "just not found; running zig build/test/lint equivalents" >&2
     zig build
     zig build test
-    zig fmt --check src/
+    zig_version="$(zig version)"
+    case "$zig_version" in
+        0.15.2)
+            zig fmt --check src/
+            ;;
+        0.16.0)
+            ;;
+        *)
+            echo "unsupported Zig formatter version: $zig_version" >&2
+            exit 1
+            ;;
+    esac
     zig build run -- src/**/*.zig
 fi
 


### PR DESCRIPTION
## Issue

Task 11 required closing the open Zig 0.16 migration policy decisions and aligning the roadmap, support guidance, formatter policy, and release documentation with the dual-frontend workflow already shipped.

## Solution

Adopt a fixed support window for Zig 0.15.2 release artifacts through v0.17.x, with v0.18.0 as the first release without that artifact. Keep Zig 0.15.2 as the sole canonical formatter and defer a frontend-detecting launcher.

Record the decisions and rationale in the migration plan, update contributor, usage, and release documentation, and make `just lint` enforce the canonical formatter policy while both pinned frontends continue to be validated.

## Context

- [PR #114](https://github.com/forketyfork/zwanzig/pull/114) added dual-frontend CI validation.
- [PR #115](https://github.com/forketyfork/zwanzig/pull/115) added dual-frontend release packaging.
- The migration plan leaves release-tag artifact verification open until a release is actually run.
