### PR TITLE
fix(release): apply macOS SDK workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,19 @@ jobs:
         with:
           version: ${{ matrix.zig_version }}
 
+      - name: Apply Zig 0.15.2 macOS SDK workaround
+        if: runner.os == 'macOS' && matrix.zig_version == '0.15.2'
+        shell: bash
+        run: |
+          unset SDKROOT DEVELOPER_DIR
+          . "$GITHUB_WORKSPACE/scripts/setup-macos-sdk-workaround.sh"
+
+          workaround_root="$GITHUB_WORKSPACE/.tmp/macos-sdk-workaround"
+          if [ -d "$workaround_root/developer" ]; then
+            echo "DEVELOPER_DIR=$workaround_root/developer" >> "$GITHUB_ENV"
+            echo "$workaround_root/bin" >> "$GITHUB_PATH"
+          fi
+
       - name: Build release binary
         run: zig build -Doptimize=ReleaseFast
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1]
+
+### Fixed
+
+- macOS ARM64 release builds embedding Zig 0.15.2 now use a compatible SDK. ([ziglang/zig#31756](https://codeberg.org/ziglang/zig/issues/31756))
+
 ## [0.15.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ nix develop .#zig016 -c just build
 Pin Zwanzig as a dependency in your Zig project. This command adds the dependency URL and content hash to `build.zig.zon`:
 
 ```bash
-zig fetch --save=zwanzig https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.15.0.tar.gz
+zig fetch --save=zwanzig https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.15.1.tar.gz
 ```
 
 Add a lint step to `build.zig`:
@@ -95,7 +95,7 @@ permissions:
   security-events: write
 
 env:
-  ZWANZIG_VERSION: v0.15.0
+  ZWANZIG_VERSION: v0.15.1
   ZWANZIG_ZIG_FRONTEND: 0.15.2
 
 jobs:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zwanzig,
-    .version = "0.15.0",
+    .version = "0.15.1",
     .fingerprint = 0x82777a3c96d925a2,
     .minimum_zig_version = "0.15.2",
     .dependencies = .{},

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -34,7 +34,7 @@ in the 0.15.2 shell and runs the remaining lint checks in the 0.16.0 shell.
 
 On macOS 26.x hosts the active `MacOSX.sdk/usr/lib/libSystem.tbd` only advertises `arm64e-macos`, so Zig 0.15.2 cannot link the build runner and emits a long list of undefined libSystem symbols (`__availability_version_check`, `_realpath$DARWIN_EXTSN`, etc.). Upstream tracker: <https://codeberg.org/ziglang/zig/issues/31756>.
 
-`flake.nix`'s Darwin `shellHook` sources `scripts/setup-macos-sdk-workaround.sh`, which detects the broken stub and, when needed, materializes a fake `DEVELOPER_DIR` under `.tmp/macos-sdk-workaround` that points at `MacOSX15.4.sdk` (the most recent SDK that still lists `arm64-macos`). A narrow `xcrun --sdk macosx --show-sdk-path` shim is prepended to `PATH` so Zig's internal SDK lookup picks up the same path. The hook is a no-op when the active SDK already advertises `arm64-macos`, when `MacOSX15.4.sdk` is missing, or on non-Darwin systems.
+`flake.nix`'s Darwin `shellHook` sources `scripts/setup-macos-sdk-workaround.sh`, which detects the broken stub and, when needed, materializes a fake `DEVELOPER_DIR` under `.tmp/macos-sdk-workaround` that points at `MacOSX15.4.sdk` (the most recent SDK that still lists `arm64-macos`). A narrow `xcrun --sdk macosx --show-sdk-path` shim is prepended to `PATH` so Zig's internal SDK lookup picks up the same path. The hook is a no-op when the active SDK already advertises `arm64-macos`, when `MacOSX15.4.sdk` is missing, or on non-Darwin systems. The macOS Zig 0.15.2 release job sources the same script and persists its `DEVELOPER_DIR` and shim path for the build step.
 
 Remove the script and the corresponding `flake.nix` lines once Zwanzig moves off Zig 0.15.2 or upstream resolves the arm64e-only stub regression.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -79,7 +79,7 @@ Without arguments, zwanzig scans the current directory for `.zig` files. It skip
 Add zwanzig to your project:
 
 ```bash
-zig fetch --save https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.15.0.tar.gz
+zig fetch --save https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.15.1.tar.gz
 ```
 
 Then wire a lint step in your `build.zig`:

--- a/docs/ZIG_0_16_MIGRATION_PLAN.md
+++ b/docs/ZIG_0_16_MIGRATION_PLAN.md
@@ -476,7 +476,7 @@ git commit -m "docs: add Zig 0.16 migration breakage inventory"
 **Status: reviewed and closed.** The compat implementation is present on
 `main` from the work covered by Tasks 1–6. Tasks 8 and 9 are complete. Task 10's
 dual-frontend release workflow and documentation are implemented; its criteria
-that require an actual release tag remain open until that release is run.
+that require a successful release tag remain open until that release completes.
 
 #### Status quo
 
@@ -667,8 +667,9 @@ one canonical Code Scanning upload.
 
 `.github/workflows/release.yml` validates and builds both Zig 0.15.2 and Zig
 0.16.0. Its platform matrix covers Linux x86_64, macOS aarch64, and Windows
-x86_64, and the asset name includes the embedded frontend. The workflow has not
-yet been exercised by an actual release tag on this migration branch.
+x86_64, and the asset name includes the embedded frontend. The v0.15.0 release
+attempt passed both validation legs but failed to link the macOS Zig 0.15.2
+artifact because the release job did not apply the existing SDK workaround.
 
 #### Objectives
 
@@ -718,7 +719,7 @@ make the embedded language frontend unambiguous before download.
 
 Tasks 1–9 are complete and checked off above. Task 10's dual-frontend release
 workflow, artifact naming, and user documentation are implemented, while the
-criteria requiring a real release tag remain open. Task 7's support lifetime,
+criteria requiring a successful release tag remain open. Task 7's support lifetime,
 canonical formatter, and launcher decisions are now adopted and recorded in
 its "Review decisions (adopted)" section.
 


### PR DESCRIPTION
## Issue

The `v0.15.0` tag's release validation completed, but the macOS ARM64 artifact embedding Zig 0.15.2 failed to link because the release job did not apply the established macOS SDK workaround.

## Solution

Apply the existing SDK workaround only to the affected macOS/Zig 0.15.2 release matrix leg and export its environment for the build step. Bump the package and installation references to `v0.15.1`, and document the failed release attempt in the migration roadmap.

## Context

- Failed release run: https://github.com/forketyfork/zwanzig/actions/runs/33084979049
- Upstream Zig issue: https://codeberg.org/ziglang/zig/issues/31756
